### PR TITLE
Centralize serialization code

### DIFF
--- a/lib/fun_with_flags/flag.ex
+++ b/lib/fun_with_flags/flag.ex
@@ -13,16 +13,6 @@ defmodule FunWithFlags.Flag do
   end
 
 
-  def from_redis(name, []), do: new(name, [])
-  def from_redis(name, list) when is_list(list) do
-    gates =
-      list
-      |> Enum.chunk(2)
-      |> Enum.map(&Gate.from_redis/1)
-    new(name, gates)
-  end
-
-
   @spec enabled?(t, options) :: boolean
   def enabled?(flag, options \\ [])
 

--- a/lib/fun_with_flags/gate.ex
+++ b/lib/fun_with_flags/gate.ex
@@ -29,19 +29,6 @@ defmodule FunWithFlags.Gate do
   end
 
 
-  def from_redis(["boolean", enabled]) do
-    %__MODULE__{type: :boolean, for: nil, enabled: parse_bool(enabled)}
-  end
-
-  def from_redis(["actor/" <> actor_id, enabled]) do
-    %__MODULE__{type: :actor, for: actor_id, enabled: parse_bool(enabled)}
-  end
-
-  def from_redis(["group/" <> group_name, enabled]) do
-    %__MODULE__{type: :group, for: String.to_atom(group_name), enabled: parse_bool(enabled)}
-  end
-
-
   def boolean?(%__MODULE__{type: :boolean}), do: true
   def boolean?(%__MODULE__{type: _}),        do: false
 
@@ -78,7 +65,4 @@ defmodule FunWithFlags.Gate do
     end
   end
 
-
-  def parse_bool("true"), do: true
-  def parse_bool(_), do: false
 end

--- a/lib/fun_with_flags/store.ex
+++ b/lib/fun_with_flags/store.ex
@@ -23,11 +23,11 @@ defmodule FunWithFlags.Store do
 
 
   defp try_to_use_the_cached_value(:expired, value, flag_name) do
-    Logger.warn "FunWithFlags: coulnd't load flag '#{flag_name}' from Redis, falling back to stale cached value from ETS"
+    Logger.warn "FunWithFlags: coulnd't load flag '#{flag_name}' from storage, falling back to stale cached value from ETS"
     {:ok, value}
   end
   defp try_to_use_the_cached_value(_, _, flag_name) do
-    raise "Can't load feature flag '#{flag_name}' from neither Redis nor the cache"
+    raise "Can't load feature flag '#{flag_name}' from neither storage nor the cache"
   end
 
 
@@ -50,7 +50,7 @@ defmodule FunWithFlags.Store do
 
 
   def reload(flag_name) do
-    Logger.debug("FunWithFlags: reloading cached flag '#{flag_name}' from Redis")
+    Logger.debug("FunWithFlags: reloading cached flag '#{flag_name}' from storage ")
     @persistence.get(flag_name)
     |> cache_persistence_result()
   end

--- a/lib/fun_with_flags/store/persistent/redis.ex
+++ b/lib/fun_with_flags/store/persistent/redis.ex
@@ -22,7 +22,7 @@ defmodule FunWithFlags.Store.Persistent.Redis do
 
   def get(flag_name) do
     case Redix.command(@conn, ["HGETALL", format(flag_name)]) do
-      {:ok, data}   -> {:ok, Flag.from_redis(flag_name, data)}
+      {:ok, data}   -> {:ok, Serializer.flag_from_redis(flag_name, data)}
       {:error, why} -> {:error, redis_error(why)}
       _             -> {:error, :unknown}
     end

--- a/lib/fun_with_flags/store/persistent/redis.ex
+++ b/lib/fun_with_flags/store/persistent/redis.ex
@@ -3,7 +3,7 @@ defmodule FunWithFlags.Store.Persistent.Redis do
 
   alias FunWithFlags.{Config, Flag, Gate}
   alias FunWithFlags.Notifications.Redis, as: NotifiRedis
-  alias FunWithFlags.Store.Serializer
+  alias FunWithFlags.Store.Serializer.Redis, as: Serializer
 
   @conn __MODULE__
   @conn_options [name: @conn, sync_connect: false]

--- a/lib/fun_with_flags/store/serializer.ex
+++ b/lib/fun_with_flags/store/serializer.ex
@@ -1,4 +1,4 @@
-defmodule FunWithFlags.Store.Serializer do
+defmodule FunWithFlags.Store.Serializer.Redis do
   @moduledoc false
   alias FunWithFlags.Gate
   alias FunWithFlags.Flag

--- a/lib/fun_with_flags/store/serializer.ex
+++ b/lib/fun_with_flags/store/serializer.ex
@@ -1,9 +1,10 @@
 defmodule FunWithFlags.Store.Serializer do
   @moduledoc false
   alias FunWithFlags.Gate
+  alias FunWithFlags.Flag
 
   @type redis_hash_pair :: [String.t]
-  
+
   @spec to_redis(FunWithFlags::Gate.t) :: redis_hash_pair
 
   def to_redis(%Gate{type: :boolean, for: nil, enabled: enabled}) do
@@ -17,4 +18,29 @@ defmodule FunWithFlags.Store.Serializer do
   def to_redis(%Gate{type: :group, for: group, enabled: enabled}) do
     ["group/#{group}", to_string(enabled)]
   end
+
+
+  def gate_from_redis(["boolean", enabled]) do
+    %Gate{type: :boolean, for: nil, enabled: parse_bool(enabled)}
+  end
+
+  def gate_from_redis(["actor/" <> actor_id, enabled]) do
+    %Gate{type: :actor, for: actor_id, enabled: parse_bool(enabled)}
+  end
+
+  def gate_from_redis(["group/" <> group_name, enabled]) do
+    %Gate{type: :group, for: String.to_atom(group_name), enabled: parse_bool(enabled)}
+  end
+
+  def flag_from_redis(name, []), do: Flag.new(name, [])
+  def flag_from_redis(name, list) when is_list(list) do
+    gates =
+      list
+      |> Enum.chunk(2)
+      |> Enum.map(&__MODULE__.gate_from_redis/1)
+    Flag.new(name, gates)
+  end
+
+  defp parse_bool("true"), do: true
+  defp parse_bool(_), do: false
 end

--- a/test/fun_with_flags/flag_test.exs
+++ b/test/fun_with_flags/flag_test.exs
@@ -10,48 +10,6 @@ defmodule FunWithFlags.FlagTest do
   end
 
 
-  describe "from_redis(name, [gate, data])" do
-    test "with empty data it returns an empty flag" do
-      assert %Flag{name: :kiwi, gates: []} = Flag.from_redis(:kiwi, [])
-    end
-
-    test "with boolean gate data it returns a simple boolean flag" do
-      assert(
-        %Flag{name: :kiwi, gates: [%Gate{type: :boolean, enabled: true}]} =
-          Flag.from_redis(:kiwi, ["boolean", "true"])
-      )
-
-      assert(
-        %Flag{name: :kiwi, gates: [%Gate{type: :boolean, enabled: false}]} =
-          Flag.from_redis(:kiwi, ["boolean", "false"])
-      )
-    end
-
-    test "with more than one gate it returns a composite flag" do
-      flag = %Flag{name: :peach, gates: [
-        %Gate{type: :boolean, enabled: true},
-        %Gate{type: :actor, for: "user:123", enabled: false},
-      ]}
-      assert ^flag = Flag.from_redis(:peach, ["boolean", "true", "actor/user:123", "false"])
-
-      flag = %Flag{name: :apricot, gates: [
-        %Gate{type: :actor, for: "string:albicocca", enabled: true},
-        %Gate{type: :boolean, enabled: false},
-        %Gate{type: :actor, for: "user:123", enabled: false},
-        %Gate{type: :group, for: :penguins, enabled: true},
-      ]}
-
-      raw_redis_data = [
-        "actor/string:albicocca", "true",
-        "boolean", "false",
-        "actor/user:123", "false",
-        "group/penguins", "true"
-      ]
-      assert ^flag = Flag.from_redis(:apricot, raw_redis_data)
-    end
-  end
-
-
   describe "enabled?(flag) - only flag parameter, no options" do
     test "it returns true if the flag has a boolean value = true" do
       flag = %Flag{name: :banana, gates: [Gate.new(:boolean, true)]}

--- a/test/fun_with_flags/gate_test.exs
+++ b/test/fun_with_flags/gate_test.exs
@@ -39,24 +39,6 @@ defmodule FunWithFlags.GateTest do
   end
 
 
-  describe "from_redis() returns a Gate struct" do
-    test "with boolean data" do
-      assert %Gate{type: :boolean, for: nil, enabled: true} = Gate.from_redis(["boolean", "true"])
-      assert %Gate{type: :boolean, for: nil, enabled: false} = Gate.from_redis(["boolean", "false"])
-    end
-
-    test "with actor data" do
-      assert %Gate{type: :actor, for: "anything", enabled: true} = Gate.from_redis(["actor/anything", "true"])
-      assert %Gate{type: :actor, for: "really:123", enabled: false} = Gate.from_redis(["actor/really:123", "false"])
-    end
-
-    test "with group data" do
-      assert %Gate{type: :group, for: :fishes, enabled: true} = Gate.from_redis(["group/fishes", "true"])
-      assert %Gate{type: :group, for: :cetacea, enabled: false} = Gate.from_redis(["group/cetacea", "false"])
-    end
-  end
-
-
   describe "enabled?(gate), for boolean gates" do
     test "without extra arguments, it simply checks the value of the gate" do
       gate = %Gate{type: :boolean, for: nil, enabled: true}

--- a/test/fun_with_flags/store/serializer_test.exs
+++ b/test/fun_with_flags/store/serializer_test.exs
@@ -3,7 +3,7 @@ defmodule FunWithFlags.Store.SerializerTest do
 
   alias FunWithFlags.Flag
   alias FunWithFlags.Gate
-  alias FunWithFlags.Store.Serializer
+  alias FunWithFlags.Store.Serializer.Redis, as: Serializer
 
   describe "to_redis(gate) returns a List ready to be saved in Redis" do
     test "with a boolean gate" do

--- a/test/fun_with_flags/store/serializer_test.exs
+++ b/test/fun_with_flags/store/serializer_test.exs
@@ -1,6 +1,7 @@
 defmodule FunWithFlags.Store.SerializerTest do
   use ExUnit.Case, async: true
 
+  alias FunWithFlags.Flag
   alias FunWithFlags.Gate
   alias FunWithFlags.Store.Serializer
 
@@ -31,4 +32,63 @@ defmodule FunWithFlags.Store.SerializerTest do
       assert ["group/swimmers", "false"] = Serializer.to_redis(gate)
     end
   end
+
+  describe "flag_from_redis(name, [gate, data])" do
+    test "with empty data it returns an empty flag" do
+      assert %Flag{name: :kiwi, gates: []} = Serializer.flag_from_redis(:kiwi, [])
+    end
+
+    test "with boolean gate data it returns a simple boolean flag" do
+      assert(
+        %Flag{name: :kiwi, gates: [%Gate{type: :boolean, enabled: true}]} =
+          Serializer.flag_from_redis(:kiwi, ["boolean", "true"])
+      )
+
+      assert(
+        %Flag{name: :kiwi, gates: [%Gate{type: :boolean, enabled: false}]} =
+          Serializer.flag_from_redis(:kiwi, ["boolean", "false"])
+      )
+    end
+
+    test "with more than one gate it returns a composite flag" do
+      flag = %Flag{name: :peach, gates: [
+        %Gate{type: :boolean, enabled: true},
+        %Gate{type: :actor, for: "user:123", enabled: false},
+      ]}
+      assert ^flag = Serializer.flag_from_redis(:peach, ["boolean", "true", "actor/user:123", "false"])
+
+      flag = %Flag{name: :apricot, gates: [
+        %Gate{type: :actor, for: "string:albicocca", enabled: true},
+        %Gate{type: :boolean, enabled: false},
+        %Gate{type: :actor, for: "user:123", enabled: false},
+        %Gate{type: :group, for: :penguins, enabled: true},
+      ]}
+
+      raw_redis_data = [
+        "actor/string:albicocca", "true",
+        "boolean", "false",
+        "actor/user:123", "false",
+        "group/penguins", "true"
+      ]
+      assert ^flag = Serializer.flag_from_redis(:apricot, raw_redis_data)
+    end
+  end
+
+  describe "gate_from_redis() returns a Gate struct" do
+    test "with boolean data" do
+      assert %Gate{type: :boolean, for: nil, enabled: true} = Serializer.gate_from_redis(["boolean", "true"])
+      assert %Gate{type: :boolean, for: nil, enabled: false} = Serializer.gate_from_redis(["boolean", "false"])
+    end
+
+    test "with actor data" do
+      assert %Gate{type: :actor, for: "anything", enabled: true} = Serializer.gate_from_redis(["actor/anything", "true"])
+      assert %Gate{type: :actor, for: "really:123", enabled: false} = Serializer.gate_from_redis(["actor/really:123", "false"])
+    end
+
+    test "with group data" do
+      assert %Gate{type: :group, for: :fishes, enabled: true} = Serializer.gate_from_redis(["group/fishes", "true"])
+      assert %Gate{type: :group, for: :cetacea, enabled: false} = Serializer.gate_from_redis(["group/cetacea", "false"])
+    end
+  end
+
 end

--- a/test/fun_with_flags/store_test.exs
+++ b/test/fun_with_flags/store_test.exs
@@ -431,7 +431,7 @@ defmodule FunWithFlags.StoreTest do
       assert {:miss, :not_found, nil} = Cache.get(name)
 
       with_mock(PersiRedis, [], get: fn(^name) -> {:error, "mocked error"} end) do
-        assert_raise RuntimeError, "Can't load feature flag '#{name}' from neither Redis nor the cache", fn() ->
+        assert_raise RuntimeError, "Can't load feature flag '#{name}' from neither storage nor the cache", fn() ->
           Store.lookup(name)
         end
         assert called(PersiRedis.get(name))


### PR DESCRIPTION
Centralizes the serialization code to/from Redis. This will make it easier in future to create alternative storage implementations, and in the more immediate it makes the code a bit tidier.

(Note: this is the same as a previous pull request which got 'poluted' with additional changes. I've broken those out into a series of branches in my fork, and will continue moving forward one branch at a time towards my own personal goal here, which is an Ecto storage + BEAM process for change notification persistence layer. This way upstream can pick up changes as far it makes sense to do so.)