### PR TITLE
Support for Phoenix.PubSub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ elixir:
   - 1.4
 otp_release:
   - 19.3
-  - 19.2
   - 18.3
 env:
   - CACHE_ENABLED=true
+  - CACHE_ENABLED=true TEST_OPTS='--exclude redis_pubsub --no-start' PUBSUB_BROKER=phoenix_pubsub
   - CACHE_ENABLED=false TEST_OPTS='--only integration'
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ otp_release:
   - 18.3
 env:
   - CACHE_ENABLED=true
-  - CACHE_ENABLED=true TEST_OPTS='--exclude redis_pubsub --no-start' PUBSUB_BROKER=phoenix_pubsub
+  - CACHE_ENABLED=true TEST_OPTS='--exclude redis_pubsub --include phoenix_pubsub --no-start' PUBSUB_BROKER=phoenix_pubsub
   - CACHE_ENABLED=false TEST_OPTS='--only integration'
 services:
   - redis-server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 ## Unreleased
 
+New Features:
+
+* Added support for Phoenix.PubSub as an alternative transport for the cache busting notifications.
+* Added ability to enable the ETS cache but disable the cache-busting notifications, as it can be useful when running on a single node.
+
+Other changes:
+
 * Upgraded `redix` and `redix_pubsub` dependencies.
-* Added ability to enable the ETS cache but disable the cache-busting notifications, as it can be useful when running on a single node. Updated available Mix config options.
-* Internal changes to better support different adapters.
+* Internal project and supervision changes to better support different adapters.
+* Updated the Mix configuration options.
 * More rational test setup.
 
 ## v0.7.1

--- a/config/test.exs
+++ b/config/test.exs
@@ -16,3 +16,13 @@ config :fun_with_flags, :cache,
   ttl: 60
 
 config :logger, level: :error
+
+
+
+
+if System.get_env("PUBSUB_BROKER") == "phoenix_pubsub" do
+  config :fun_with_flags, :cache_bust_notifications, [
+    adapter: FunWithFlags.Notifications.PhoenixPubSub,
+    client: :fwf_test
+  ]
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -18,8 +18,6 @@ config :fun_with_flags, :cache,
 config :logger, level: :error
 
 
-
-
 if System.get_env("PUBSUB_BROKER") == "phoenix_pubsub" do
   config :fun_with_flags, :cache_bust_notifications, [
     adapter: FunWithFlags.Notifications.PhoenixPubSub,

--- a/lib/fun_with_flags/config.ex
+++ b/lib/fun_with_flags/config.ex
@@ -83,6 +83,11 @@ defmodule FunWithFlags.Config do
   end
 
 
+  def pubsub_client do
+    Keyword.get(notifications_config(), :client)
+  end
+
+
   # Should the application emir cache busting/syncing notifications?
   # Defaults to false if we are not using a cache and if there is no
   # notifications adapter configured. Else, it defaults to true.

--- a/lib/fun_with_flags/notifications/phoenix_pubsub.ex
+++ b/lib/fun_with_flags/notifications/phoenix_pubsub.ex
@@ -60,18 +60,17 @@ defmodule FunWithFlags.Notifications.PhoenixPubSub do
       case Phoenix.PubSub.subscribe(client(), @channel) do
         :ok ->
           # All good
-          Logger.debug "FunWithFlags: Subscribed to to Phoenix.PubSub process #{inspect(client())}."
           :ok
         {:error, reason} ->
           # Handled application errors
-          Logger.error "FunWithFlags: Cannot subscribe to Phoenix.PubSub process #{inspect(client())} ({:error, #{inspect(reason)}})."
+          Logger.debug "FunWithFlags: Cannot subscribe to Phoenix.PubSub process #{inspect(client())} ({:error, #{inspect(reason)}})."
           try_again_to_subscribe(attempt)
       end
     rescue
       e ->
         # The pubsub process was probably not running. This happens when using it in Phoenix, as it tries to connect the
         # first time while the application is booting, and the Phoenix.PubSub process is not fully started yet.
-        Logger.error "FunWithFlags: Cannot subscribe to Phoenix.PubSub process #{inspect(client())} (exception: #{inspect(e)})."
+        Logger.debug "FunWithFlags: Cannot subscribe to Phoenix.PubSub process #{inspect(client())} (exception: #{inspect(e)})."
         try_again_to_subscribe(attempt)
     end
   end

--- a/lib/fun_with_flags/notifications/phoenix_pubsub.ex
+++ b/lib/fun_with_flags/notifications/phoenix_pubsub.ex
@@ -6,10 +6,8 @@ defmodule FunWithFlags.Notifications.PhoenixPubSub do
   require Logger
   alias FunWithFlags.{Config, Store}
 
-  # Host applications will inject this. It's supposed to be
-  # an active pubsub PID or name atom.
-  @conn Config.pubsub_client()
   @channel "fun_with_flags_changes"
+  @max_attempts 5
 
 
   def worker_spec do
@@ -38,7 +36,7 @@ defmodule FunWithFlags.Notifications.PhoenixPubSub do
 
   def publish_change(flag_name) do
     Task.start fn() ->
-      Phoenix.PubSub.broadcast!(@conn, @channel,
+      Phoenix.PubSub.broadcast!(client(), @channel,
         {:fwf_changes, {:updated, flag_name, unique_id()}}
       )
     end
@@ -52,22 +50,44 @@ defmodule FunWithFlags.Notifications.PhoenixPubSub do
   # The unique_id will become the state of the GenServer
   #
   def init(unique_id) do
-    subscribe()
+    subscribe(1)
     {:ok, unique_id}
   end
 
 
-  defp subscribe do
+  defp subscribe(attempt) when attempt <= @max_attempts do
     try do
-      case Phoenix.PubSub.subscribe(@conn, @channel) do
-        :ok -> :ok
+      case Phoenix.PubSub.subscribe(client(), @channel) do
+        :ok ->
+          # All good
+          Logger.debug "FunWithFlags: Subscribed to to Phoenix.PubSub process #{inspect(client())}."
+          :ok
         {:error, reason} ->
-          Logger.error "FunWithFlags: Cannot subscribe to Phoenix.PubSub process #{inspect(@conn)} ({:error, #{inspect(reason)}})."
+          # Handled application errors
+          Logger.error "FunWithFlags: Cannot subscribe to Phoenix.PubSub process #{inspect(client())} ({:error, #{inspect(reason)}})."
+          try_again_to_subscribe(attempt)
       end
     rescue
       e ->
-        Logger.error "FunWithFlags: Cannot subscribe to Phoenix.PubSub process #{inspect(@conn)} (exception: #{inspect(e)})."
+        # The pubsub process was probably not running. This happens when using it in Phoenix, as it tries to connect the
+        # first time while the application is booting, and the Phoenix.PubSub process is not fully started yet.
+        Logger.error "FunWithFlags: Cannot subscribe to Phoenix.PubSub process #{inspect(client())} (exception: #{inspect(e)})."
+        try_again_to_subscribe(attempt)
     end
+  end
+
+
+  # We can't connect to the PubSub process. Possibly because it didn't start.
+  #
+  defp subscribe(_) do
+    raise "Tried to subscribe to Phoenix.PubSub process #{inspect(client())} #{@max_attempts} times. Giving up."
+  end
+
+
+  # Wait 1 second and try again
+  #
+  defp try_again_to_subscribe(attempt) do
+    Process.send_after(self(), {:subscribe_retry, (attempt + 1)}, 1000)
   end
 
 
@@ -87,6 +107,18 @@ defmodule FunWithFlags.Notifications.PhoenixPubSub do
     Task.start(Store, :reload, [name])
     {:noreply, unique_id}
   end
+
+
+  # When subscribing to the pubsub process fails, the process sends itself a delayed message
+  # to try again. It will be handlerd here.
+  #
+  def handle_info({:subscribe_retry, attempt}, unique_id) do
+    Logger.debug "FunWithFlags: retrying to subscribe to Phoenix.PubSub, attempt #{attempt}."
+    subscribe(attempt)
+    {:noreply, unique_id}
+  end
+
+  defp client, do: Config.pubsub_client()
 end
 
 end # Code.ensure_loaded?

--- a/lib/fun_with_flags/notifications/phoenix_pubsub.ex
+++ b/lib/fun_with_flags/notifications/phoenix_pubsub.ex
@@ -1,0 +1,77 @@
+if Code.ensure_loaded?(Phoenix.PubSub) do
+
+defmodule FunWithFlags.Notifications.PhoenixPubSub do
+  @moduledoc false
+  use GenServer
+  require Logger
+  alias FunWithFlags.{Config, Store}
+
+  # Host applications will inject this. It's supposed to be
+  # an active pubsub PID or name atom.
+  @conn Config.pubsub_client()
+  @channel "fun_with_flags_changes"
+
+
+  def worker_spec do
+    import Supervisor.Spec, only: [worker: 3]
+    worker(__MODULE__, [], [restart: :permanent])
+  end
+
+
+  # Initialize the Genserver with a unique id (binary).
+  # This id will stay with the genserver until it's terminated, and is
+  # used to build the outgoing notification payloads and to ignore
+  # incoming messages that originated from this node.
+  #
+  def start_link do
+    GenServer.start_link(__MODULE__, Config.build_unique_id, [name: __MODULE__])
+  end
+
+  # Get the unique_id for this running node, which is the state
+  # passed to the GenServer when it's (re)started.
+  #
+  def unique_id do
+    {:ok, unique_id} = GenServer.call(__MODULE__, :get_unique_id)
+    unique_id
+  end  
+
+
+  def publish_change(flag_name) do
+    Task.start fn() ->
+      Phoenix.PubSub.broadcast!(@conn, @channel,
+        {:fwf_changes, {:updated, flag_name, unique_id()}}
+      )
+    end
+  end
+
+
+  # ------------------------------------------------------------
+  # GenServer callbacks
+
+
+  # The unique_id will become the state of the GenServer
+  #
+  def init(unique_id) do
+    :ok = Phoenix.PubSub.subscribe(@conn, @channel)
+    {:ok, unique_id}
+  end
+
+  def handle_call(:get_unique_id, _from, unique_id) do
+    {:reply, {:ok, unique_id}, unique_id}
+  end
+
+
+  def handle_info({:fwf_changes, {:updated, _name, unique_id}}, unique_id) do
+    # received my own message, doing nothing
+    {:noreply, unique_id}
+  end
+
+  def handle_info({:fwf_changes, {:updated, name, _}}, unique_id) do
+    # received message from another node, reload the flag
+    Logger.debug("FunWithFlags: received change notifiation for flag '#{name}'")
+    Task.start(Store, :reload, [name])
+    {:noreply, unique_id}
+  end
+end
+
+end # Code.ensure_loaded?

--- a/lib/fun_with_flags/notifications/phoenix_pubsub.ex
+++ b/lib/fun_with_flags/notifications/phoenix_pubsub.ex
@@ -52,9 +52,24 @@ defmodule FunWithFlags.Notifications.PhoenixPubSub do
   # The unique_id will become the state of the GenServer
   #
   def init(unique_id) do
-    :ok = Phoenix.PubSub.subscribe(@conn, @channel)
+    subscribe()
     {:ok, unique_id}
   end
+
+
+  defp subscribe do
+    try do
+      case Phoenix.PubSub.subscribe(@conn, @channel) do
+        :ok -> :ok
+        {:error, reason} ->
+          Logger.error "FunWithFlags: Cannot subscribe to Phoenix.PubSub process #{inspect(@conn)} ({:error, #{inspect(reason)}})."
+      end
+    rescue
+      e ->
+        Logger.error "FunWithFlags: Cannot subscribe to Phoenix.PubSub process #{inspect(@conn)} (exception: #{inspect(e)})."
+    end
+  end
+
 
   def handle_call(:get_unique_id, _from, unique_id) do
     {:reply, {:ok, unique_id}, unique_id}

--- a/lib/fun_with_flags/notifications/redis.ex
+++ b/lib/fun_with_flags/notifications/redis.ex
@@ -1,3 +1,5 @@
+if Code.ensure_loaded?(Redix.PubSub) do
+
 defmodule FunWithFlags.Notifications.Redis do
   @moduledoc false
   use GenServer
@@ -118,3 +120,5 @@ defmodule FunWithFlags.Notifications.Redis do
 
   end
 end
+
+end # Code.ensure_loaded?

--- a/mix.exs
+++ b/mix.exs
@@ -77,7 +77,7 @@ defmodule FunWithFlags.Mixfile do
     )
   end
 
-  # PUBSUB_BROKER=phoenix_pubsub mix test --force --no-start --exclude redis_pubsub --include phoenix_pubsub
+  # PUBSUB_BROKER=phoenix_pubsub iex -S mix test --force --no-start --exclude redis_pubsub --include phoenix_pubsub
   #
   defp run_tests_phoenix_pubsub(_) do
     Mix.shell.cmd(

--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,7 @@ defmodule FunWithFlags.Mixfile do
 
   defp aliases do
     [
-      {:"test.all", [&run_tests/1, &run_integration_tests_no_cache/1]},
+      {:"test.all", [&run_tests/1, &run_integration_tests_no_cache/1, &run_tests_phoenix_pubsub/1]},
       {:"test.phx", [&run_tests_phoenix_pubsub/1]},
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,8 @@ defmodule FunWithFlags.Mixfile do
       {:ex_doc, "~> 0.15", only: :dev},
       {:mock, "~> 0.2.1", only: [:test, :test_no_cache]},
       {:redix, "~> 0.5.2"},
-      {:redix_pubsub, "~> 0.3.0"},
+      {:redix_pubsub, "~> 0.3.0", optional: true},
+      {:phoenix_pubsub, "~> 1.0", optional: true},
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -77,7 +77,7 @@ defmodule FunWithFlags.Mixfile do
     )
   end
 
-  # PUBSUB_BROKER=phoenix_pubsub iex -S mix test --force --no-start --exclude redis_pubsub --include phoenix_pubsub
+  # PUBSUB_BROKER=phoenix_pubsub mix test --force --no-start --exclude redis_pubsub --include phoenix_pubsub
   #
   defp run_tests_phoenix_pubsub(_) do
     Mix.shell.cmd(

--- a/mix.exs
+++ b/mix.exs
@@ -52,6 +52,7 @@ defmodule FunWithFlags.Mixfile do
   defp aliases do
     [
       {:"test.all", [&run_tests/1, &run_integration_tests_no_cache/1]},
+      {:"test.phx", [&run_tests_phoenix_pubsub/1]},
     ]
   end
 
@@ -73,6 +74,18 @@ defmodule FunWithFlags.Mixfile do
     Mix.shell.cmd(
       "mix test --color --force --only integration",
       env: [{"CACHE_ENABLED", "false"}]
+    )
+  end
+
+  # PUBSUB_BROKER=phoenix_pubsub iex -S mix test --force --no-start --exclude redis_pubsub --include phoenix_pubsub
+  #
+  defp run_tests_phoenix_pubsub(_) do
+    Mix.shell.cmd(
+      "mix test --color --force --no-start --exclude redis_pubsub --include phoenix_pubsub", 
+      env: [
+        {"CACHE_ENABLED", "true"},
+        {"PUBSUB_BROKER", "phoenix_pubsub"},
+      ]
     )
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -3,5 +3,6 @@
   "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
   "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []},
   "mock": {:hex, :mock, "0.2.1", "bfdba786903e77f9c18772dee472d020ceb8ef000783e737725a4c8f54ad28ec", [:mix], [{:meck, "~> 0.8.2", [hex: :meck, optional: false]}]},
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.1", "c10ddf6237007c804bf2b8f3c4d5b99009b42eca3a0dfac04ea2d8001186056a", [:mix], []},
   "redix": {:hex, :redix, "0.5.2", "82a7b3cf9141a8d3de7d38d321717fe7ae6f998561cd87d374ff9012db87913a", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}]},
   "redix_pubsub": {:hex, :redix_pubsub, "0.3.0", "e04a3517f632afcfc781d43ec8439c32b3fd0ff09f2d2815c003ad6458d4bfa3", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:redix, "~> 0.5.2", [hex: :redix, optional: false]}]}}

--- a/test/fun_with_flags/config_test.exs
+++ b/test/fun_with_flags/config_test.exs
@@ -111,22 +111,24 @@ defmodule FunWithFlags.ConfigTest do
     end
 
     test "returns false if no notification adapter is configured" do
-      original = Config.notifications_adapter()
+      original_adapter = Config.notifications_adapter()
+      original_client = Config.pubsub_client
       Mix.Config.persist(fun_with_flags: [cache_bust_notifications: [adapter: nil]])
       refute Config.change_notifications_enabled?
 
       # cleanup
-      reset_notifications_defaults(original)
+      reset_notifications_defaults(original_adapter, original_client)
       assert Config.change_notifications_enabled?
     end
 
     test "returns false if it's explicitly disabled" do
-      original = Config.notifications_adapter()
+      original_adapter = Config.notifications_adapter()
+      original_client = Config.pubsub_client
       Mix.Config.persist(fun_with_flags: [cache_bust_notifications: [enabled: false]])
       refute Config.change_notifications_enabled?
 
       # cleanup
-      reset_notifications_defaults(original)
+      reset_notifications_defaults(original_adapter, original_client)
       assert Config.change_notifications_enabled?
     end
   end
@@ -144,10 +146,10 @@ defmodule FunWithFlags.ConfigTest do
     Mix.Config.persist(fun_with_flags: [cache: [enabled: true, ttl: 60]])
   end
 
-  defp reset_notifications_defaults(adapter) do
+  defp reset_notifications_defaults(adapter, client) do
     Mix.Config.persist(fun_with_flags: [
       cache_bust_notifications: [
-        enabled: true, adapter: adapter
+        enabled: true, adapter: adapter, client: client
       ]
     ])
   end

--- a/test/fun_with_flags/config_test.exs
+++ b/test/fun_with_flags/config_test.exs
@@ -89,7 +89,10 @@ defmodule FunWithFlags.ConfigTest do
 
 
   test "notifications_adapter() returns a module" do
-    assert FunWithFlags.Notifications.Redis = Config.notifications_adapter
+    assert Config.notifications_adapter() in [
+      FunWithFlags.Notifications.Redis,
+      FunWithFlags.Notifications.PhoenixPubSub,
+    ]
   end
 
 
@@ -108,20 +111,22 @@ defmodule FunWithFlags.ConfigTest do
     end
 
     test "returns false if no notification adapter is configured" do
+      original = Config.notifications_adapter()
       Mix.Config.persist(fun_with_flags: [cache_bust_notifications: [adapter: nil]])
       refute Config.change_notifications_enabled?
 
       # cleanup
-      reset_notifications_defaults()
+      reset_notifications_defaults(original)
       assert Config.change_notifications_enabled?
     end
 
     test "returns false if it's explicitly disabled" do
+      original = Config.notifications_adapter()
       Mix.Config.persist(fun_with_flags: [cache_bust_notifications: [enabled: false]])
       refute Config.change_notifications_enabled?
 
       # cleanup
-      reset_notifications_defaults()
+      reset_notifications_defaults(original)
       assert Config.change_notifications_enabled?
     end
   end
@@ -139,10 +144,10 @@ defmodule FunWithFlags.ConfigTest do
     Mix.Config.persist(fun_with_flags: [cache: [enabled: true, ttl: 60]])
   end
 
-  defp reset_notifications_defaults do
+  defp reset_notifications_defaults(adapter) do
     Mix.Config.persist(fun_with_flags: [
       cache_bust_notifications: [
-        enabled: true, adapter: FunWithFlags.Notifications.Redis
+        enabled: true, adapter: adapter
       ]
     ])
   end

--- a/test/fun_with_flags/notifications/phoenix_pubsub_test.exs
+++ b/test/fun_with_flags/notifications/phoenix_pubsub_test.exs
@@ -1,0 +1,7 @@
+defmodule FunWithFlags.Notifications.PhoenixPubSubTest do
+  use ExUnit.Case, async: false
+  # import FunWithFlags.TestUtils
+  # import Mock
+
+  # alias FunWithFlags.Notifications.PhoenixPubSub, as: PubSub
+end

--- a/test/fun_with_flags/notifications/phoenix_pubsub_test.exs
+++ b/test/fun_with_flags/notifications/phoenix_pubsub_test.exs
@@ -1,7 +1,187 @@
 defmodule FunWithFlags.Notifications.PhoenixPubSubTest do
   use ExUnit.Case, async: false
-  # import FunWithFlags.TestUtils
-  # import Mock
+  import FunWithFlags.TestUtils
+  import Mock
 
-  # alias FunWithFlags.Notifications.PhoenixPubSub, as: PubSub
+  alias FunWithFlags.Notifications.PhoenixPubSub, as: PubSub
+
+  @moduletag :phoenix_pubsub
+
+  describe "unique_id()" do
+    test "it returns a string" do
+      assert is_binary(PubSub.unique_id())
+    end
+
+    test "it always returns the same ID for the GenServer" do
+      assert PubSub.unique_id() == PubSub.unique_id()
+    end
+
+    test "the ID changes if the GenServer restarts" do
+      a = PubSub.unique_id()
+      kill_process(PubSub)
+      :timer.sleep(1)
+      refute a == PubSub.unique_id()
+    end
+  end
+
+
+  describe "publish_change(flag_name)" do
+    setup do
+      {:ok, name: unique_atom()}
+    end
+
+    test "returns a PID (it starts a Task)", %{name: name} do
+      assert {:ok, pid} = PubSub.publish_change(name)
+      assert is_pid(pid)
+    end
+
+    test "publishes a notification to Phoenix.PubSub", %{name: name} do
+      u_id = PubSub.unique_id()
+
+      with_mocks([
+        {Phoenix.PubSub, [:passthrough], []}
+      ]) do
+        assert {:ok, _pid} = PubSub.publish_change(name)
+        :timer.sleep(10)
+
+        assert called(
+          Phoenix.PubSub.broadcast!(
+            :fwf_test,
+            "fun_with_flags_changes",
+            {:fwf_changes, {:updated, name, u_id}}
+          )
+        )
+      end
+    end
+
+    test "causes other subscribers to receive a Phoenix.PubSub notification", %{name: name} do
+      channel = "fun_with_flags_changes"
+      u_id = PubSub.unique_id()
+
+      :ok = Phoenix.PubSub.subscribe(:fwf_test, channel) # implicit self
+
+      assert {:ok, _pid} = PubSub.publish_change(name)
+
+      payload = {:updated, name, u_id}
+      
+      receive do
+        {:fwf_changes, ^payload} -> :ok
+      after
+        500 -> flunk "Haven't received any message after 0.5 seconds"
+      end
+
+      # cleanup
+
+      :ok = Phoenix.PubSub.unsubscribe(:fwf_test, channel) # implicit self
+    end
+  end
+
+
+  test "it receives messages if something is published on Phoenix.PubSub" do
+    u_id = PubSub.unique_id()
+    client = FunWithFlags.Config.pubsub_client()
+    channel = "fun_with_flags_changes"
+    message = {:fwf_changes, {:updated, :foobar, u_id}}
+
+    with_mock(PubSub, [:passthrough], []) do
+      Phoenix.PubSub.broadcast!(client, channel, message)
+
+      :timer.sleep(1)
+
+      assert called(
+        PubSub.handle_info(message, u_id)
+      )
+    end
+  end
+
+
+  describe "integration: message handling" do
+    alias FunWithFlags.{Store, Config}
+
+
+    test "when the message comes from this same process, it is ignored" do
+      u_id = PubSub.unique_id()
+      client = FunWithFlags.Config.pubsub_client()
+      channel = "fun_with_flags_changes"
+      message = {:fwf_changes, {:updated, :a_flag_name, u_id}}
+      
+      with_mock(Store, [:passthrough], []) do
+        Phoenix.PubSub.broadcast!(client, channel, message)
+        :timer.sleep(30)
+        refute called(Store.reload(:a_flag_name))
+      end
+    end
+
+
+    test "when the message comes from another process, it reloads the flag" do
+      another_u_id = Config.build_unique_id()
+      refute another_u_id == PubSub.unique_id()
+
+      client = FunWithFlags.Config.pubsub_client()
+      channel = "fun_with_flags_changes"
+      message = {:fwf_changes, {:updated, :a_flag_name, another_u_id}}
+      
+      with_mock(Store, [:passthrough], []) do
+        Phoenix.PubSub.broadcast!(client, channel, message)
+        :timer.sleep(30)
+        assert called(Store.reload(:a_flag_name))
+      end
+    end
+  end
+
+
+  describe "integration: side effects" do
+    alias FunWithFlags.Store.Cache
+    alias FunWithFlags.Store.Persistent.Redis, as: PersiRedis
+    alias FunWithFlags.{Store, Config, Gate, Flag}
+
+    setup do
+      name = unique_atom()
+      gate = %Gate{type: :boolean, enabled: true}
+      stored_flag = %Flag{name: name, gates: [gate]}
+
+      gate2 = %Gate{type: :boolean, enabled: false}
+      cached_flag = %Flag{name: name, gates: [gate2]}
+
+      {:ok, ^stored_flag} = PersiRedis.put(name, gate)
+      :timer.sleep(10)
+      {:ok, ^cached_flag} = Cache.put(cached_flag)
+
+      assert {:ok, ^stored_flag} = PersiRedis.get(name)
+      assert {:ok, ^cached_flag} = Cache.get(name)
+
+      refute match? ^stored_flag, cached_flag
+
+      {:ok, name: name, stored_flag: stored_flag, cached_flag: cached_flag}
+    end
+
+
+    @tag :redis_persistence
+    test "when the message comes from this same process, the Cached value is not changed", %{name: name, cached_flag: cached_flag} do
+      u_id = PubSub.unique_id()
+      client = FunWithFlags.Config.pubsub_client()
+      channel = "fun_with_flags_changes"
+      message = {:fwf_changes, {:updated, name, u_id}}
+      
+      Phoenix.PubSub.broadcast!(client, channel, message)
+      :timer.sleep(30)
+      assert {:ok, ^cached_flag} = Cache.get(name)
+    end
+
+
+    @tag :redis_persistence
+    test "when the message comes from another process, the Cached value is reloaded", %{name: name, cached_flag: cached_flag, stored_flag: stored_flag} do
+      another_u_id = Config.build_unique_id()
+      refute another_u_id == PubSub.unique_id()
+
+      client = FunWithFlags.Config.pubsub_client()
+      channel = "fun_with_flags_changes"
+      message = {:fwf_changes, {:updated, name, another_u_id}}
+      
+      assert {:ok, ^cached_flag} = Cache.get(name)
+      Phoenix.PubSub.broadcast!(client, channel, message)
+      :timer.sleep(30)
+      assert {:ok, ^stored_flag} = Cache.get(name)
+    end
+  end
 end

--- a/test/fun_with_flags/notifications/redis_test.exs
+++ b/test/fun_with_flags/notifications/redis_test.exs
@@ -210,7 +210,7 @@ defmodule FunWithFlags.Notifications.RedisTest do
       {:ok, name: name, stored_flag: stored_flag, cached_flag: cached_flag}
     end
 
-
+    @tag :redis_persistence
     test "when the message is not valid, the Cached value is not changed", %{name: name, cached_flag: cached_flag} do
       channel = "fun_with_flags_changes"
       
@@ -219,7 +219,7 @@ defmodule FunWithFlags.Notifications.RedisTest do
       assert {:ok, ^cached_flag} = Cache.get(name)
     end
 
-
+    @tag :redis_persistence
     test "when the message comes from this same process, the Cached value is not changed", %{name: name, cached_flag: cached_flag} do
       u_id = NotifiRedis.unique_id()
       channel = "fun_with_flags_changes"
@@ -230,7 +230,7 @@ defmodule FunWithFlags.Notifications.RedisTest do
       assert {:ok, ^cached_flag} = Cache.get(name)
     end
 
-
+    @tag :redis_persistence
     test "when the message comes from another process, the Cached value is reloaded", %{name: name, cached_flag: cached_flag, stored_flag: stored_flag} do
       another_u_id = Config.build_unique_id()
       refute another_u_id == NotifiRedis.unique_id()

--- a/test/fun_with_flags/notifications/redis_test.exs
+++ b/test/fun_with_flags/notifications/redis_test.exs
@@ -5,6 +5,7 @@ defmodule FunWithFlags.Notifications.RedisTest do
 
   alias FunWithFlags.Notifications.Redis, as: NotifiRedis
 
+  @moduletag :redis_pubsub
 
   describe "unique_id()" do
     test "it returns a string" do

--- a/test/fun_with_flags/store/persistent/redis_test.exs
+++ b/test/fun_with_flags/store/persistent/redis_test.exs
@@ -7,6 +7,8 @@ defmodule FunWithFlags.Store.Persistent.RedisTest do
   alias FunWithFlags.{Config, Flag, Gate}
   alias FunWithFlags.Notifications.Redis, as: NotifiRedis
 
+  @moduletag :redis_persistence
+
   setup_all do
     on_exit(__MODULE__, fn() -> clear_redis_test_db() end)
     :ok
@@ -55,6 +57,7 @@ defmodule FunWithFlags.Store.Persistent.RedisTest do
     end
 
 
+    @tag :redis_pubsub
     test "when change notifications are enabled, put() will publish a notification to Redis", %{name: name, gate: gate, flag: flag} do
       assert Config.change_notifications_enabled?
 
@@ -75,7 +78,7 @@ defmodule FunWithFlags.Store.Persistent.RedisTest do
       end
     end
 
-
+    @tag :redis_pubsub
     test "when change notifications are enabled, put() will cause other subscribers to receive a Redis notification", %{name: name, gate: gate, flag: flag} do
       assert Config.change_notifications_enabled?
       channel = "fun_with_flags_changes"
@@ -115,7 +118,7 @@ defmodule FunWithFlags.Store.Persistent.RedisTest do
       Process.exit(receiver, :kill)
     end
 
-
+    @tag :redis_pubsub
     test "when change notifications are NOT enabled, put() will NOT publish a notification to Redis", %{name: name, gate: gate, flag: flag} do
       with_mocks([
         {Config, [], [change_notifications_enabled?: fn() -> false end]},
@@ -193,7 +196,7 @@ defmodule FunWithFlags.Store.Persistent.RedisTest do
       assert {:ok, %Flag{name: ^name, gates: [^bool_gate]}} = PersiRedis.delete(name, %Gate{type: :actor, for: "I'm not really there", enabled: false})
     end
 
-
+    @tag :redis_pubsub
     test "when change notifications are enabled, delete(flag_name, gate) will publish a notification to Redis", %{name: name, group_gate: group_gate} do
       assert Config.change_notifications_enabled?
 
@@ -214,7 +217,7 @@ defmodule FunWithFlags.Store.Persistent.RedisTest do
       end
     end
 
-
+    @tag :redis_pubsub
     test "when change notifications are enabled, delete(flag_name, gate) will cause other subscribers to receive a Redis notification", %{name: name, group_gate: group_gate} do
       assert Config.change_notifications_enabled?
       channel = "fun_with_flags_changes"
@@ -254,7 +257,7 @@ defmodule FunWithFlags.Store.Persistent.RedisTest do
       Process.exit(receiver, :kill)
     end
 
-
+    @tag :redis_pubsub
     test "when change notifications are NOT enabled, delete(flag_name, gate) will NOT publish a notification to Redis", %{name: name, group_gate: group_gate} do
       with_mocks([
         {Config, [], [change_notifications_enabled?: fn() -> false end]},
@@ -318,7 +321,7 @@ defmodule FunWithFlags.Store.Persistent.RedisTest do
       assert {:ok, %Flag{name: ^name, gates: []}} = PersiRedis.delete(name)
     end
 
-
+    @tag :redis_pubsub
     test "when change notifications are enabled, delete(flag_name) will publish a notification to Redis", %{name: name} do
       assert Config.change_notifications_enabled?
 
@@ -339,7 +342,7 @@ defmodule FunWithFlags.Store.Persistent.RedisTest do
       end
     end
 
-
+    @tag :redis_pubsub
     test "when change notifications are enabled, delete(flag_name) will cause other subscribers to receive a Redis notification", %{name: name} do
       assert Config.change_notifications_enabled?
       channel = "fun_with_flags_changes"
@@ -379,7 +382,7 @@ defmodule FunWithFlags.Store.Persistent.RedisTest do
       Process.exit(receiver, :kill)
     end
 
-
+    @tag :redis_pubsub
     test "when change notifications are NOT enabled, delete(flag_name) will NOT publish a notification to Redis", %{name: name} do
       with_mocks([
         {Config, [], [change_notifications_enabled?: fn() -> false end]},

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,15 @@
+IO.puts "System.get_env(\"PUBSUB_BROKER\") -> #{System.get_env("PUBSUB_BROKER") }"
+if System.get_env("PUBSUB_BROKER") == "phoenix_pubsub" do
+  # Start a Phoenix.PubSub process for the tests.
+  # The `:fwf_test` connection name will be injected into this
+  # library in `config/test..exs`.
+  {:ok, _pid} = Phoenix.PubSub.PG2.start_link(:fwf_test, [pool_size: 1])
+end
+
+# With some configurations the tests are run with `--no-start`, because
+# we want to start the Phoenix.PubSub process before starting the application.
+Application.ensure_all_started(:fun_with_flags)
+
 IO.puts "Running tests with $TEST_OPTS='#{System.get_env("TEST_OPTS")}'"
 FunWithFlags.TestUtils.use_redis_test_db()
 ExUnit.start()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,10 @@
 IO.puts "$PUBSUB_BROKER=#{System.get_env("PUBSUB_BROKER") }"
 
+# By default exclude the phoenix pubsub tests.
+ExUnit.configure exclude: [
+  :phoenix_pubsub,
+]
+
 if System.get_env("PUBSUB_BROKER") == "phoenix_pubsub" do
   # Start a Phoenix.PubSub process for the tests.
   # The `:fwf_test` connection name will be injected into this

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,5 @@
-IO.puts "System.get_env(\"PUBSUB_BROKER\") -> #{System.get_env("PUBSUB_BROKER") }"
+IO.puts "$PUBSUB_BROKER=#{System.get_env("PUBSUB_BROKER") }"
+
 if System.get_env("PUBSUB_BROKER") == "phoenix_pubsub" do
   # Start a Phoenix.PubSub process for the tests.
   # The `:fwf_test` connection name will be injected into this
@@ -11,5 +12,7 @@ end
 Application.ensure_all_started(:fun_with_flags)
 
 IO.puts "Running tests with $TEST_OPTS='#{System.get_env("TEST_OPTS")}'"
+IO.puts "Notifications adapter: #{inspect(FunWithFlags.Config.notifications_adapter())}"
+
 FunWithFlags.TestUtils.use_redis_test_db()
 ExUnit.start()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,3 @@
-IO.puts "$PUBSUB_BROKER=#{System.get_env("PUBSUB_BROKER") }"
-
 # By default exclude the phoenix pubsub tests.
 ExUnit.configure exclude: [
   :phoenix_pubsub,
@@ -8,7 +6,7 @@ ExUnit.configure exclude: [
 if System.get_env("PUBSUB_BROKER") == "phoenix_pubsub" do
   # Start a Phoenix.PubSub process for the tests.
   # The `:fwf_test` connection name will be injected into this
-  # library in `config/test..exs`.
+  # library in `config/test.exs`.
   {:ok, _pid} = Phoenix.PubSub.PG2.start_link(:fwf_test, [pool_size: 1])
 end
 
@@ -17,6 +15,7 @@ end
 Application.ensure_all_started(:fun_with_flags)
 
 IO.puts "Running tests with $TEST_OPTS='#{System.get_env("TEST_OPTS")}'"
+IO.puts "$PUBSUB_BROKER=#{System.get_env("PUBSUB_BROKER") }"
 IO.puts "Notifications adapter: #{inspect(FunWithFlags.Config.notifications_adapter())}"
 
 FunWithFlags.TestUtils.use_redis_test_db()


### PR DESCRIPTION
Add support to use `Phoenix.PubSub` as the transport for the cache-invalidating notifications.