### PR TITLE
Fix compiled in configs for working with umbrella

### DIFF
--- a/lib/fun_with_flags.ex
+++ b/lib/fun_with_flags.ex
@@ -25,9 +25,11 @@ defmodule FunWithFlags do
   explanation.
   """
 
-  alias FunWithFlags.{Flag, Gate}
+  alias FunWithFlags.{Config, Flag, Gate}
 
-  @store FunWithFlags.Config.store_module
+  defp store() do
+    Config.store_module()
+  end
 
   @type options :: Keyword.t
 
@@ -77,7 +79,7 @@ defmodule FunWithFlags do
 
 
   def enabled?(flag_name, []) when is_atom(flag_name) do
-    case @store.lookup(flag_name) do
+    case store().lookup(flag_name) do
       {:ok, flag} -> Flag.enabled?(flag)
       _           -> false
     end
@@ -88,7 +90,7 @@ defmodule FunWithFlags do
   end
 
   def enabled?(flag_name, [for: item]) when is_atom(flag_name) do
-    case @store.lookup(flag_name) do
+    case store().lookup(flag_name) do
       {:ok, flag} -> Flag.enabled?(flag, for: item)
       _           -> false
     end
@@ -154,7 +156,7 @@ defmodule FunWithFlags do
   def enable(flag_name, options \\ [])
 
   def enable(flag_name, []) when is_atom(flag_name) do
-    {:ok, flag} = @store.put(flag_name, Gate.new(:boolean, true))
+    {:ok, flag} = store().put(flag_name, Gate.new(:boolean, true))
     verify(flag)
   end
 
@@ -164,7 +166,7 @@ defmodule FunWithFlags do
 
   def enable(flag_name, [for_actor: actor]) when is_atom(flag_name) do
     gate = Gate.new(:actor, actor, true)
-    {:ok, flag} = @store.put(flag_name, gate)
+    {:ok, flag} = store().put(flag_name, gate)
     verify(flag, for: actor)
   end
 
@@ -175,7 +177,7 @@ defmodule FunWithFlags do
 
   def enable(flag_name, [for_group: group_name]) when is_atom(flag_name) do
     gate = Gate.new(:group, group_name, true)
-    {:ok, _flag} = @store.put(flag_name, gate)
+    {:ok, _flag} = store().put(flag_name, gate)
     {:ok, true}
   end
 
@@ -242,7 +244,7 @@ defmodule FunWithFlags do
   def disable(flag_name, options \\ [])
 
   def disable(flag_name, []) when is_atom(flag_name) do
-    {:ok, flag} = @store.put(flag_name, Gate.new(:boolean, false))
+    {:ok, flag} = store().put(flag_name, Gate.new(:boolean, false))
     verify(flag)
   end
 
@@ -252,7 +254,7 @@ defmodule FunWithFlags do
 
   def disable(flag_name, [for_actor: actor]) when is_atom(flag_name) do
     gate = Gate.new(:actor, actor, false)
-    {:ok, flag} = @store.put(flag_name, gate)
+    {:ok, flag} = store().put(flag_name, gate)
     verify(flag, for: actor)
   end
 
@@ -262,7 +264,7 @@ defmodule FunWithFlags do
 
   def disable(flag_name, [for_group: group_name]) when is_atom(flag_name) do
     gate = Gate.new(:group, group_name, false)
-    {:ok, _flag} = @store.put(flag_name, gate)
+    {:ok, _flag} = store().put(flag_name, gate)
     {:ok, false}
   end
 
@@ -333,7 +335,7 @@ defmodule FunWithFlags do
   def clear(flag_name, options \\ [])
 
   def clear(flag_name, []) when is_atom(flag_name) do
-    {:ok, _flag} = @store.delete(flag_name)
+    {:ok, _flag} = store().delete(flag_name)
     :ok
   end
 
@@ -356,7 +358,7 @@ defmodule FunWithFlags do
   end
 
   defp _clear_gate(flag_name, gate) do
-    {:ok, _flag} = @store.delete(flag_name, gate)
+    {:ok, _flag} = store().delete(flag_name, gate)
     :ok
   end
 
@@ -369,7 +371,7 @@ defmodule FunWithFlags do
   for example, will be considered disabled.
   """
   @spec all_flag_names() :: {:ok, [atom]} | {:ok, []}
-  defdelegate all_flag_names(), to: @store
+  def all_flag_names(), do: store().all_flag_names()
 
   @doc """
   Returns a list of all the flags currently configured, as data structures.
@@ -381,7 +383,7 @@ defmodule FunWithFlags do
   To query the value of a flag, please use the `enabled?2` function instead.
   """
   @spec all_flags() :: {:ok, [FunWithFlags.Flag.t]} | {:ok, []}
-  defdelegate all_flags(), to: @store
+  def all_flags(), do: store().all_flags()
 
 
   defp verify(flag) do

--- a/lib/fun_with_flags/application.ex
+++ b/lib/fun_with_flags/application.ex
@@ -13,7 +13,7 @@ defmodule FunWithFlags.Application do
 
   defp children do
     [
-      FunWithFlags.Store.Persistent.adapter.worker_spec,
+      FunWithFlags.Config.persistence_adapter().worker_spec,
       cache_spec(),
       notifications_spec(),
     ]

--- a/lib/fun_with_flags/simple_store.ex
+++ b/lib/fun_with_flags/simple_store.ex
@@ -2,7 +2,7 @@ defmodule FunWithFlags.SimpleStore do
   @moduledoc false
 
   defp persistence do
-    FunWithFlags.Store.Persistent.adapter()
+    FunWithFlags.Config.persistence_adapter()
   end
 
 

--- a/lib/fun_with_flags/simple_store.ex
+++ b/lib/fun_with_flags/simple_store.ex
@@ -1,19 +1,21 @@
 defmodule FunWithFlags.SimpleStore do
   @moduledoc false
 
-  @persistence FunWithFlags.Store.Persistent.adapter
+  defp persistence do
+    FunWithFlags.Store.Persistent.adapter()
+  end
 
 
   def lookup(flag_name) do
-    case @persistence.get(flag_name) do
+    case persistence().get(flag_name) do
       {:ok, flag} -> {:ok, flag}
       _ -> raise "Can't load feature flag"
     end
   end
 
-  defdelegate put(flag_name, gate), to: @persistence
-  defdelegate delete(flag_name, gate), to: @persistence
-  defdelegate delete(flag_name), to: @persistence
-  defdelegate all_flags(), to: @persistence
-  defdelegate all_flag_names(), to: @persistence
+  def put(flag_name, gate), do: persistence().put(flag_name, gate)
+  def delete(flag_name, gate), do: persistence().delete(flag_name, gate)
+  def delete(flag_name), do: persistence().delete(flag_name)
+  def all_flags(), do: persistence().all_flags()
+  def all_flag_names(), do: persistence().all_flag_names()
 end

--- a/lib/fun_with_flags/store.ex
+++ b/lib/fun_with_flags/store.ex
@@ -5,7 +5,7 @@ defmodule FunWithFlags.Store do
   alias FunWithFlags.Store.Cache
 
   defp persistence do
-    FunWithFlags.Store.Persistent.adapter()
+    FunWithFlags.Config.persistence_adapter()
   end
 
   def lookup(flag_name) do

--- a/lib/fun_with_flags/store.ex
+++ b/lib/fun_with_flags/store.ex
@@ -3,15 +3,17 @@ defmodule FunWithFlags.Store do
 
   require Logger
   alias FunWithFlags.Store.Cache
-  @persistence FunWithFlags.Store.Persistent.adapter
 
+  defp persistence do
+    FunWithFlags.Store.Persistent.adapter()
+  end
 
   def lookup(flag_name) do
     case Cache.get(flag_name) do
       {:ok, flag} ->
         {:ok, flag}
       {:miss, reason, stale_value_or_nil} ->
-        case @persistence.get(flag_name) do
+        case persistence().get(flag_name) do
           {:ok, flag} ->
             Cache.put(flag) 
             {:ok, flag}
@@ -32,32 +34,32 @@ defmodule FunWithFlags.Store do
 
 
   def put(flag_name, gate) do
-    @persistence.put(flag_name, gate)
+    persistence().put(flag_name, gate)
     |> cache_persistence_result()
   end
 
 
   def delete(flag_name, gate) do
-    @persistence.delete(flag_name, gate)
+    persistence().delete(flag_name, gate)
     |> cache_persistence_result()
   end
 
 
   def delete(flag_name) do
-    @persistence.delete(flag_name)
+    persistence().delete(flag_name)
     |> cache_persistence_result()
   end
 
 
   def reload(flag_name) do
     Logger.debug("FunWithFlags: reloading cached flag '#{flag_name}' from storage ")
-    @persistence.get(flag_name)
+    persistence().get(flag_name)
     |> cache_persistence_result()
   end
 
 
-  defdelegate all_flags(), to: @persistence
-  defdelegate all_flag_names(), to: @persistence
+  def all_flags(), do: persistence().all_flags()
+  def all_flag_names(), do: persistence().all_flag_names()
 
 
   defp cache_persistence_result(result) do

--- a/lib/fun_with_flags/store/cache.ex
+++ b/lib/fun_with_flags/store/cache.ex
@@ -8,7 +8,10 @@ defmodule FunWithFlags.Store.Cache do
   @table_options [
     :set, :protected, :named_table, {:read_concurrency, true}
   ]
-  @ttl FunWithFlags.Config.cache_ttl
+
+  defp ttl do
+    FunWithFlags.Config.cache_ttl()
+  end
 
   def start_link do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
@@ -28,7 +31,7 @@ defmodule FunWithFlags.Store.Cache do
   end
 
   defp validate(name, flag = %Flag{name: name}, timestamp) do
-    if Timestamps.expired?(timestamp, @ttl) do
+    if Timestamps.expired?(timestamp, ttl()) do
       {:miss, :expired, flag}
     else
       {:ok, flag}

--- a/lib/fun_with_flags/store/persistent.ex
+++ b/lib/fun_with_flags/store/persistent.ex
@@ -1,5 +1,0 @@
-defmodule FunWithFlags.Store.Persistent do
-  @moduledoc false
-
-  def adapter, do: FunWithFlags.Config.persistence_adapter
-end

--- a/lib/fun_with_flags/store/persistent.ex
+++ b/lib/fun_with_flags/store/persistent.ex
@@ -1,7 +1,5 @@
 defmodule FunWithFlags.Store.Persistent do
   @moduledoc false
 
-  @adapter FunWithFlags.Config.persistence_adapter
-
-  def adapter, do: @adapter
+  def adapter, do: FunWithFlags.Config.persistence_adapter
 end

--- a/lib/fun_with_flags/store/persistent/ecto.ex
+++ b/lib/fun_with_flags/store/persistent/ecto.ex
@@ -9,7 +9,9 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
 
   import Ecto.Query
 
-  @repo Config.ecto_repo()
+  defp repo do
+    Config.ecto_repo()
+  end
 
   def worker_spec do
     nil
@@ -20,7 +22,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
     name_string = to_string(flag_name)
     query = from(r in Record, where: r.flag_name == ^name_string)
     try do
-      results = @repo.all(query)
+      results = repo().all(query)
       flag = deserialize(flag_name, results)
       {:ok, flag}
     rescue
@@ -36,7 +38,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
       conflict_target: [:flag_name, :gate_type, :target] # the unique index
     ]
 
-    case @repo.insert(changeset, options) do
+    case repo().insert(changeset, options) do
       {:ok, _struct} ->
         {:ok, flag} = get(flag_name)
         publish_change(flag_name)
@@ -64,7 +66,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
     )
 
     try do
-      {_count, _} = @repo.delete_all(query)
+      {_count, _} = repo().delete_all(query)
       {:ok, flag} = get(flag_name)
       publish_change(flag_name)
       {:ok, flag}
@@ -89,7 +91,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
     )
 
     try do
-      {_count, _} = @repo.delete_all(query)
+      {_count, _} = repo().delete_all(query)
       {:ok, flag} = get(flag_name)
       publish_change(flag_name)
       {:ok, flag}
@@ -101,7 +103,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
 
   def all_flags do
     flags = 
-      @repo.all(Record)
+      repo().all(Record)
       |> Enum.group_by(&(&1.flag_name))
       |> Enum.map(fn ({name, records}) -> deserialize(name, records) end)
     {:ok, flags}
@@ -110,7 +112,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
 
   def all_flag_names do
     query = from(r in Record, select: r.flag_name, distinct: true)
-    strings = @repo.all(query)
+    strings = repo().all(query)
     atoms = Enum.map(strings, &String.to_atom(&1))
     {:ok, atoms}
   end

--- a/test/fun_with_flags/store/persistent/ecto_test.exs
+++ b/test/fun_with_flags/store/persistent/ecto_test.exs
@@ -107,7 +107,7 @@ defmodule FunWithFlags.Store.Persistent.EctoTest do
       u_id = NotifiPhoenix.unique_id()
 
       with_mocks([
-        {Config, [], [change_notifications_enabled?: fn() -> false end]},
+        {Config, [:passthrough], [change_notifications_enabled?: fn() -> false end]},
         {Phoenix.PubSub, [:passthrough], []}
       ]) do
         assert {:ok, ^flag} = PersiEcto.put(name, gate)
@@ -237,7 +237,7 @@ defmodule FunWithFlags.Store.Persistent.EctoTest do
       u_id = NotifiPhoenix.unique_id()
 
       with_mocks([
-        {Config, [], [change_notifications_enabled?: fn() -> false end]},
+        {Config, [:passthrough], [change_notifications_enabled?: fn() -> false end]},
         {Phoenix.PubSub, [:passthrough], []}
       ]) do
         assert {:ok, %Flag{name: ^name}} = PersiEcto.delete(name, group_gate)
@@ -352,7 +352,7 @@ defmodule FunWithFlags.Store.Persistent.EctoTest do
       u_id = NotifiPhoenix.unique_id()
 
       with_mocks([
-        {Config, [], [change_notifications_enabled?: fn() -> false end]},
+        {Config, [:passthrough], [change_notifications_enabled?: fn() -> false end]},
         {Phoenix.PubSub, [:passthrough], []}
       ]) do
         assert {:ok, %Flag{name: ^name, gates: []}} = PersiEcto.delete(name)

--- a/test/fun_with_flags/store/persistent_test.exs
+++ b/test/fun_with_flags/store/persistent_test.exs
@@ -1,14 +1,15 @@
 defmodule FunWithFlags.Store.PersistentTest do
   use FunWithFlags.TestCase, async: true
   alias FunWithFlags.Store.Persistent
+  alias FunWithFlags.Config
 
   @tag :redis_persistence
   test "adapter() returns the Redis adapter" do
-    assert FunWithFlags.Store.Persistent.Redis = Persistent.adapter
+    assert Persistent.Redis = Config.persistence_adapter()
   end
 
   @tag :ecto_persistence
   test "adapter() returns the Ecto adapter" do
-    assert FunWithFlags.Store.Persistent.Ecto = Persistent.adapter
+    assert Persistent.Ecto = Config.persistence_adapter()
   end
 end


### PR DESCRIPTION
The problem with compiling in configs is that if you have
umbrella projects that are both setting the same config,
either one will get their compiled config in and the other
will fail. Since you can't introduce circular deps in your
umbrella application you would have to introduce an other
application that all of the apps that need FunWithFlags
would need to depend on.

Fixes: #14