### PR TITLE
Update README for redis persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ When using Redis for persistence and/or cache-busting PubSub it is necessary to 
 ```elixir
 # the Redis options will be forwarded to Redix.
 config :fun_with_flags, :redis,
-  host: 'localhost',
+  host: "localhost",
   port: 6379,
   database: 0
 


### PR DESCRIPTION
localhost was specified with single quotes and not double quotes, leading to an error if blindly copying and pasting.