### PR TITLE
Additional log message about disable notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Just as Elixir and Phoenix are meant to scale better than Ruby on Rails with hig
 ## So, caching, huh?
 
 > There are only two hard things in Computer Science: cache invalidation and naming things.
-> 
+>
 > -- Phil Karlton
 
 The reason to add an ETS cache is that, most of the time, feature flags can be considered static values. Doing a round-trip to the DB (Redis or RDBMS) is expensive in terms of time and in terms of resources, expecially if multiple flags must be checked during a single web request. In the worst cases, the load on the DB can become a cause of concern, a performance bottleneck or the source of a system failure.
@@ -332,6 +332,9 @@ config :fun_with_flags, :persistence,
 # The Redis PuSub adapter is the default, no need to set this.
 config :fun_with_flags, :cache_bust_notifications,
   [enabled: true, adapter: FunWithFlags.Notifications.Redis]
+
+# Notifications can also be disabled, which will also remove the Redis/Redix dependency
+config :fun_with_flags, :cache_bust_notifications, [enabled: false]  
 ```
 
 When using Redis for persistence and/or cache-busting PubSub it is necessary to configure the connection to the Redis instance. These options can be omitted if Redis is not being used. For example, the defaults:

--- a/lib/fun_with_flags/application.ex
+++ b/lib/fun_with_flags/application.ex
@@ -30,7 +30,8 @@ defmodule FunWithFlags.Application do
       Config.change_notifications_enabled? && Config.notifications_adapter.worker_spec
     rescue
       e in [UndefinedFunctionError] ->
-        Logger.error "FunWithFlags: Looks like you're trying to use #{Config.notifications_adapter}, but you haven't added its optional dependency to the Mixfile."
+        Logger.error "FunWithFlags: Looks like you're trying to use #{Config.notifications_adapter} for notifications, but you haven't added its optional dependency to the Mixfile."
+        Logger.error "FunWithFlags: Optionally notifications can be disabled to exclude this dependency."
         raise e
     end
   end


### PR DESCRIPTION
Currently when you are using Ecto as the persistence store you will
receiving an error message that Redis is a dependency if you have
caching enabled. I updated the error message to reflect that caching
can also be disabled.

Closes #18 