### PR TITLE
Changed ecto migration to use a natural PK

### DIFF
--- a/lib/fun_with_flags/store/persistent/ecto/record.ex
+++ b/lib/fun_with_flags/store/persistent/ecto/record.ex
@@ -5,6 +5,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto.Record do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @primary_key false
   schema "fun_with_flags_toggles" do
     field :flag_name, :string, primary_key: true
     field :gate_type, :string, primary_key: true

--- a/lib/fun_with_flags/store/persistent/ecto/record.ex
+++ b/lib/fun_with_flags/store/persistent/ecto/record.ex
@@ -5,11 +5,10 @@ defmodule FunWithFlags.Store.Persistent.Ecto.Record do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @primary_key false
   schema "fun_with_flags_toggles" do
-    field :flag_name, :string, primary_key: true
-    field :gate_type, :string, primary_key: true
-    field :target, :string, primary_key: true
+    field :flag_name, :string
+    field :gate_type, :string
+    field :target, :string
     field :enabled, :boolean
   end
 

--- a/lib/fun_with_flags/store/persistent/ecto/record.ex
+++ b/lib/fun_with_flags/store/persistent/ecto/record.ex
@@ -6,9 +6,9 @@ defmodule FunWithFlags.Store.Persistent.Ecto.Record do
   import Ecto.Changeset
 
   schema "fun_with_flags_toggles" do
-    field :flag_name, :string
-    field :gate_type, :string
-    field :target, :string
+    field :flag_name, :string, primary_key: true
+    field :gate_type, :string, primary_key: true
+    field :target, :string, primary_key: true
     field :enabled, :boolean
   end
 
@@ -38,7 +38,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto.Record do
 
   # Do not just store NULL for `target: nil`, because the unique
   # index in the table does not see NULL values as equal.
-  # 
+  #
   def serialize_target(nil), do: "_fwf_none"
   def serialize_target(str) when is_binary(str), do: str
   def serialize_target(atm) when is_atom(atm), do: to_string(atm)

--- a/priv/ecto_repo/migrations/00000000000000_create_feature_flags_table.exs
+++ b/priv/ecto_repo/migrations/00000000000000_create_feature_flags_table.exs
@@ -3,11 +3,18 @@ defmodule FunWithFlags.Dev.EctoRepo.Migrations.CreateFeatureFlagsTable do
 
   def up do
     create table(:fun_with_flags_toggles, primary_key: false) do
-      add :flag_name, :string, primary_key: true
-      add :gate_type, :string, primary_key: true
-      add :target, :string, primary_key: true
+      add :id, :bigserial, primary_key: true
+      add :flag_name, :string
+      add :gate_type, :string
+      add :target, :string
       add :enabled, :boolean
     end
+
+    create index(
+      :fun_with_flags_toggles,
+      [:flag_name, :gate_type, :target],
+      [unique: true, name: "fwf_flag_name_gate_target_idx"]
+    )
   end
 
   def down do

--- a/priv/ecto_repo/migrations/00000000000000_create_feature_flags_table.exs
+++ b/priv/ecto_repo/migrations/00000000000000_create_feature_flags_table.exs
@@ -2,18 +2,12 @@ defmodule FunWithFlags.Dev.EctoRepo.Migrations.CreateFeatureFlagsTable do
   use Ecto.Migration
 
   def up do
-    create table(:fun_with_flags_toggles) do
-      add :flag_name, :string
-      add :gate_type, :string
-      add :target, :string
+    create table(:fun_with_flags_toggles, primary_key: false) do
+      add :flag_name, :string, primary_key: true
+      add :gate_type, :string, primary_key: true
+      add :target, :string, primary_key: true
       add :enabled, :boolean
     end
-
-    create index(
-      :fun_with_flags_toggles,
-      [:flag_name, :gate_type, :target],
-      [unique: true, name: "fwf_flag_name_gate_target_idx"]
-    )
   end
 
   def down do


### PR DESCRIPTION
If a project sets ecto's `migration_primary_key` to binary_id, the
FunWithFlags Record module fails to insert the primary key because ecto
normally autogenerates this, but `@primary_key {:id, :binary_id,
autogenerate: true}` has to be set on the module.

Closes #19 