### PR TITLE
Allow configuration of redis using {:system, envvar}

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,9 @@ config :fun_with_flags, :redis,
 
 # a URL string can be used instead
 config :fun_with_flags, :redis, "redis://locahost:6379/0"
+
+# a {:system, name} tuple can be used to read from the environment
+config :fun_with_flags, :redis, {:system, "REDIS_URL"}
 ```
 
 ### Persistence Adapters

--- a/lib/fun_with_flags/config.ex
+++ b/lib/fun_with_flags/config.ex
@@ -27,6 +27,8 @@ defmodule FunWithFlags.Config do
         uri
       opts when is_list(opts) ->
         Keyword.merge(@default_redis_config, opts)
+      {:system, var} when is_binary(var) ->
+        System.get_env(var)
     end
   end
 

--- a/test/fun_with_flags/config_test.exs
+++ b/test/fun_with_flags/config_test.exs
@@ -28,6 +28,12 @@ defmodule FunWithFlags.ConfigTest do
     assert            2000 == Config.redis_config[:port]
     assert              42 == Config.redis_config[:database]
 
+    # Whe configured with a {:system, env} tuple it looks up the value in the env
+    System.put_env("123_TEST_REDIS_URL", url)
+    configure_redis_with({:system, "123_TEST_REDIS_URL"})
+    assert url == Config.redis_config
+    System.delete_env("123_TEST_REDIS_URL")
+
     # cleanup
     configure_redis_with(defaults)
   end


### PR DESCRIPTION
Hi,

Thanks for this app, really enjoying using it. Just came across one quirk when deploying to Heroku.

When deploying to Heroku, you need to set the Redis url using an environment variable. If you do this in the config like this:

```elixir
config :fun_with_flags, :redis, System.get_env("REDIS_URL")
```

and change the value in the environment config, it won't be reflected in the app until a redeploy forces a recompile. So instead it's common practise to use a system tuple like so:

```elixir
config :fun_with_flags, :redis, {:system, "REDIS_URL"}
```

This PR adds support for this configuration option.