### PR TITLE
Fix compiler warning and add --warnings-as-errors to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ otp_release:
 env:
   - CACHE_ENABLED=true  TEST_OPTS='--exclude phoenix_pubsub --exclude ecto_persistence'
   - CACHE_ENABLED=false TEST_OPTS='--only integration'
-  - CACHE_ENABLED=true  PUBSUB_BROKER=phoenix_pubsub TEST_OPTS='--no-start --exclude redis_pubsub --exclude ecto_persistence --exclude phoenix_pubsub:with_ecto --include phoenix_pubsub:with_redis --include phoenix_pubsub:true' 
+  - CACHE_ENABLED=true  PUBSUB_BROKER=phoenix_pubsub TEST_OPTS='--no-start --exclude redis_pubsub --exclude ecto_persistence --exclude phoenix_pubsub:with_ecto --include phoenix_pubsub:with_redis --include phoenix_pubsub:true'
   - CACHE_ENABLED=false PUBSUB_BROKER=phoenix_pubsub TEST_OPTS='--no-start --only integration'
-  - CACHE_ENABLED=true  PUBSUB_BROKER=phoenix_pubsub PERSISTENCE=ecto TEST_OPTS='--no-start --exclude redis_pubsub --exclude redis_persistence --exclude phoenix_pubsub:with_redis --include phoenix_pubsub:with_ecto --include phoenix_pubsub:true --include ecto_persistence' 
+  - CACHE_ENABLED=true  PUBSUB_BROKER=phoenix_pubsub PERSISTENCE=ecto TEST_OPTS='--no-start --exclude redis_pubsub --exclude redis_persistence --exclude phoenix_pubsub:with_redis --include phoenix_pubsub:with_ecto --include phoenix_pubsub:true --include ecto_persistence'
   - CACHE_ENABLED=false PUBSUB_BROKER=phoenix_pubsub PERSISTENCE=ecto TEST_OPTS='--no-start --only integration'
 matrix:
   exclude:
@@ -40,6 +40,7 @@ services:
 addons:
   postgresql: "9.6"
 script:
+  - mix compile --warnings-as-errors
   - mix test --force $TEST_OPTS
 before_script:
   - MIX_ENV=test mix ecto.create

--- a/lib/fun_with_flags/store/serializer/redis.ex
+++ b/lib/fun_with_flags/store/serializer/redis.ex
@@ -5,7 +5,7 @@ defmodule FunWithFlags.Store.Serializer.Redis do
 
   @type redis_hash_pair :: [String.t]
 
-  @spec serialize(FunWithFlags::Gate.t) :: redis_hash_pair
+  @spec serialize(fun_with_flags :: Gate.t()) :: redis_hash_pair
 
   def serialize(%Gate{type: :boolean, for: nil, enabled: enabled}) do
     ["boolean", to_string(enabled)]

--- a/lib/fun_with_flags/store/serializer/redis.ex
+++ b/lib/fun_with_flags/store/serializer/redis.ex
@@ -5,7 +5,7 @@ defmodule FunWithFlags.Store.Serializer.Redis do
 
   @type redis_hash_pair :: [String.t]
 
-  @spec serialize(fun_with_flags :: Gate.t()) :: redis_hash_pair
+  @spec serialize(FunWithFlags.Gate.t()) :: redis_hash_pair
 
   def serialize(%Gate{type: :boolean, for: nil, enabled: enabled}) do
     ["boolean", to_string(enabled)]

--- a/lib/fun_with_flags/store/serializer/redis.ex
+++ b/lib/fun_with_flags/store/serializer/redis.ex
@@ -5,7 +5,7 @@ defmodule FunWithFlags.Store.Serializer.Redis do
 
   @type redis_hash_pair :: [String.t]
 
-  @spec serialize(FunWithFlags.Gate.t()) :: redis_hash_pair
+  @spec serialize(FunWithFlags.Gate.t) :: redis_hash_pair
 
   def serialize(%Gate{type: :boolean, for: nil, enabled: enabled}) do
     ["boolean", to_string(enabled)]


### PR DESCRIPTION
```
warning: invalid type annotation. When using the | operator to represent the union of types, make sure to wrap type annotations in parentheses: FunWithFlags :: Gate.t()
  lib/fun_with_flags/store/serializer/redis.ex:8
```