### PR TITLE
Ecto Persistence: Customize UPSERT options for MySQL adapter

### DIFF
--- a/lib/fun_with_flags/store/persistent/ecto/null_repo.ex
+++ b/lib/fun_with_flags/store/persistent/ecto/null_repo.ex
@@ -12,4 +12,5 @@ defmodule FunWithFlags.NullEctoRepo do
   def update(_, _),    do: raise(@error_msg)
   def delete_all(_),   do: raise(@error_msg)
   def transaction(_),  do: raise(@error_msg)
+  def __adapter__(),   do: raise(@error_msg)
 end


### PR DESCRIPTION
`ecto_sql` [supports UPSERT operations](https://hexdocs.pm/ecto/Ecto.Repo.html#c:insert/2-upserts) for both the MySQL and Postgres adapters. Postgres requires the `conflict_target` option be supplied when performing updates, while MySQL does not support it at all.

To allow supporting both of these backends, we'll use the Repo's adapter to differentiate what kind of database we're talking to, and use that to generate the appropriate insert options.

This addresses #40. As mentioned in that issue, `.travis.yml` changes are required to begin testing against both MySQL and Postgres backends - I wasn't fully comfortable making those changes myself, as the existing build matrix and test setup is reasonably complex.