### PR TITLE
Deterministic TTL flutter proof of concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ erl_crash.dump
 
 # Redis db
 dump.rdb
+
+# The directory used by Elixir Language Server
+.elixir_ls

--- a/config/config.exs
+++ b/config/config.exs
@@ -34,7 +34,8 @@ with_ecto =
 
 config :fun_with_flags, :cache,
   enabled: with_cache,
-  ttl: 60
+  ttl: 60,
+  flutter: false
 
 
 if with_phx_pubsub do

--- a/lib/fun_with_flags/config.ex
+++ b/lib/fun_with_flags/config.ex
@@ -52,6 +52,7 @@ defmodule FunWithFlags.Config do
     end
   end
 
+
   def cache_flutter? do
     Keyword.get(ets_cache_config(), :flutter)
   end

--- a/lib/fun_with_flags/config.ex
+++ b/lib/fun_with_flags/config.ex
@@ -43,8 +43,8 @@ defmodule FunWithFlags.Config do
     ttl = Keyword.get(ets_cache_config(), :ttl)
 
     if __MODULE__.cache_flutter? do
-      flutter_percentage = 10
-      ttl_variance = round(ttl / flutter_percentage)
+      flutter_percentage = 0.1
+      ttl_variance = round(ttl * flutter_percentage)
 
       ttl + Enum.random(-ttl_variance..ttl_variance)
     else

--- a/lib/fun_with_flags/config.ex
+++ b/lib/fun_with_flags/config.ex
@@ -40,16 +40,7 @@ defmodule FunWithFlags.Config do
 
 
   def cache_ttl do
-    ttl = Keyword.get(ets_cache_config(), :ttl)
-
-    if __MODULE__.cache_flutter? do
-      flutter_percentage = 0.1
-      ttl_variance = round(ttl * flutter_percentage)
-
-      ttl + Enum.random(-ttl_variance..ttl_variance)
-    else
-      ttl
-    end
+    Keyword.get(ets_cache_config(), :ttl)
   end
 
 

--- a/lib/fun_with_flags/config.ex
+++ b/lib/fun_with_flags/config.ex
@@ -8,7 +8,8 @@ defmodule FunWithFlags.Config do
 
   @default_cache_config [
     enabled: true,
-    ttl: 900 # in seconds, 15 minutes
+    ttl: 900, # in seconds, 15 minutes
+    flutter: false # adds a random variance to TTLs to avoid hammering persistence
   ]
 
   @default_notifications_config [
@@ -39,7 +40,20 @@ defmodule FunWithFlags.Config do
 
 
   def cache_ttl do
-    Keyword.get(ets_cache_config(), :ttl)
+    ttl = Keyword.get(ets_cache_config(), :ttl)
+
+    if __MODULE__.cache_flutter? do
+      flutter_percentage = 10
+      ttl_variance = round(ttl / flutter_percentage)
+
+      ttl + Enum.random(-ttl_variance..ttl_variance)
+    else
+      ttl
+    end
+  end
+
+  def cache_flutter? do
+    Keyword.get(ets_cache_config(), :flutter)
   end
 
 

--- a/lib/fun_with_flags/store/cache.ex
+++ b/lib/fun_with_flags/store/cache.ex
@@ -51,9 +51,9 @@ defmodule FunWithFlags.Store.Cache do
     {:miss, :invalid, nil}
   end
 
+
   defp flag_stale?(timestamp, flag) do
     if Config.cache_flutter? do
-      IO.inspect(Flag.flutter_offset(flag), label: :flag_offset)
       Timestamps.expired?(timestamp, Config.cache_ttl, Flag.flutter_offset(flag))
     else
       Timestamps.expired?(timestamp, Config.cache_ttl)

--- a/lib/fun_with_flags/store/cache.ex
+++ b/lib/fun_with_flags/store/cache.ex
@@ -53,10 +53,14 @@ defmodule FunWithFlags.Store.Cache do
   end
 
   defp flag_stale?(timestamp, flag_name) do
+    ttl = Config.cache_ttl
     if Config.cache_flutter? do
-      Timestamps.expired?(timestamp, @ttl, flutter_offset(flag_name))
+      g = Timestamps.expired?(timestamp, ttl, flutter_offset(flag_name))
+      # IO.inspect(g)
+
+      g
     else
-      Timestamps.expired?(timestamp, @ttl)
+      Timestamps.expired?(timestamp, ttl)
     end
   end
 

--- a/lib/fun_with_flags/timestamps.ex
+++ b/lib/fun_with_flags/timestamps.ex
@@ -6,13 +6,6 @@ defmodule FunWithFlags.Timestamps do
   end
 
   def expired?(timestamp, ttl, flutter_offset \\ 0) do
-    n = __MODULE__.now()
-    IO.inspect(timestamp)
-    IO.inspect(ttl)
-    IO.inspect(flutter_offset)
-    IO.inspect((timestamp) - n)
-    IO.puts("---------")
-
-    (timestamp + ttl + flutter_offset) < n
+    (timestamp + ttl + flutter_offset) < __MODULE__.now()
   end
 end

--- a/lib/fun_with_flags/timestamps.ex
+++ b/lib/fun_with_flags/timestamps.ex
@@ -6,6 +6,13 @@ defmodule FunWithFlags.Timestamps do
   end
 
   def expired?(timestamp, ttl, flutter_offset \\ 0) do
-    (timestamp + ttl + flutter_offset) < __MODULE__.now()
+    n = __MODULE__.now()
+    IO.inspect(timestamp)
+    IO.inspect(ttl)
+    IO.inspect(flutter_offset)
+    IO.inspect((timestamp) - n)
+    IO.puts("---------")
+
+    (timestamp + ttl + flutter_offset) < n
   end
 end

--- a/lib/fun_with_flags/timestamps.ex
+++ b/lib/fun_with_flags/timestamps.ex
@@ -5,7 +5,7 @@ defmodule FunWithFlags.Timestamps do
     DateTime.utc_now() |> DateTime.to_unix(:second)
   end
 
-  def expired?(timestamp, ttl) do
-    (timestamp + ttl) < __MODULE__.now()
+  def expired?(timestamp, ttl, flutter_offset \\ 0) do
+    (timestamp + ttl + flutter_offset) < __MODULE__.now()
   end
 end

--- a/test/fun_with_flags/config_test.exs
+++ b/test/fun_with_flags/config_test.exs
@@ -53,17 +53,39 @@ defmodule FunWithFlags.ConfigTest do
   end
 
 
-  test "cache_ttl" do
-    # defaults to 60 seconds in test
-    assert 60 = Config.cache_ttl
+  describe "cache_ttl" do
+    test "without flutter" do
+      # defaults to 60 seconds in test
+      assert 60 = Config.cache_ttl
 
-    # can be configured
-    Mix.Config.persist(fun_with_flags: [cache: [ttl: 3600]])
-    assert 3600 = Config.cache_ttl
+      # can be configured
+      Mix.Config.persist(fun_with_flags: [cache: [ttl: 3600]])
+      assert 3600 = Config.cache_ttl
 
-    # cleanup
-    reset_cache_defaults()
-    assert 60 = Config.cache_ttl
+      # cleanup
+      reset_cache_defaults()
+      assert 60 = Config.cache_ttl
+    end
+
+    test "with flutter" do
+      # enable flutter
+      Mix.Config.persist(fun_with_flags: [cache: [flutter: true]])
+
+      # collect 100 ttls
+      ttls = Enum.map(0..100, fn _ ->
+        Config.cache_ttl
+      end)
+
+      # test that the values aren't all the same
+      # this test isn't ideal because 1, it's technically non-deterministic and,
+      # 2, it only checks that the values aren't _all_ the same.  If there were
+      # only 2 unique values, this would pass.  That said, I think it's sufficient
+      # when considering the implementation and the pitfalls of using random numbers
+      assert length(Enum.uniq(ttls)) > 1
+
+      # cleanup
+      reset_cache_defaults()
+    end
   end
 
 

--- a/test/fun_with_flags/config_test.exs
+++ b/test/fun_with_flags/config_test.exs
@@ -53,33 +53,17 @@ defmodule FunWithFlags.ConfigTest do
   end
 
 
-  describe "cache_ttl" do
-    test "without flutter" do
-      # defaults to 60 seconds in test
-      assert 60 = Config.cache_ttl
+  test "cache_ttl" do
+    # defaults to 60 seconds in test
+    assert 60 = Config.cache_ttl
 
-      # can be configured
-      Mix.Config.persist(fun_with_flags: [cache: [ttl: 3600]])
-      assert 3600 = Config.cache_ttl
+    # can be configured
+    Mix.Config.persist(fun_with_flags: [cache: [ttl: 3600]])
+    assert 3600 = Config.cache_ttl
 
-      # cleanup
-      reset_cache_defaults()
-      assert 60 = Config.cache_ttl
-    end
-
-    test "with flutter" do
-      # enable flutter and customize TTL
-      Mix.Config.persist(fun_with_flags: [cache: [flutter: true, ttl: 50]])
-
-      # seed RNG and collect TTLs
-      :rand.seed(:exsplus, {101, 102, 103})
-      ttls = Enum.map(0..5, fn _ -> Config.cache_ttl end)
-
-      assert [49, 51, 47, 45, 51, 48] = ttls
-
-      # cleanup
-      reset_cache_defaults()
-    end
+    # cleanup
+    reset_cache_defaults()
+    assert 60 = Config.cache_ttl
   end
 
 

--- a/test/fun_with_flags/config_test.exs
+++ b/test/fun_with_flags/config_test.exs
@@ -67,6 +67,20 @@ defmodule FunWithFlags.ConfigTest do
   end
 
 
+  test "cache_flutter?" do
+    # defaults to false in test
+    refute Config.cache_flutter?
+
+    # can be configured
+    Mix.Config.persist(fun_with_flags: [cache: [flutter: true]])
+    assert Config.cache_flutter?
+
+    # cleanup
+    reset_cache_defaults()
+    refute Config.cache_flutter?
+  end
+
+
   test "store_module" do
     # defaults to FunWithFlags.Store
     assert FunWithFlags.Store = Config.store_module
@@ -200,7 +214,7 @@ defmodule FunWithFlags.ConfigTest do
   end
 
   defp reset_cache_defaults do
-    Mix.Config.persist(fun_with_flags: [cache: [enabled: true, ttl: 60]])
+    Mix.Config.persist(fun_with_flags: [cache: [enabled: true, ttl: 60, flutter: false]])
   end
 
   defp reset_notifications_defaults(adapter, client) do

--- a/test/fun_with_flags/config_test.exs
+++ b/test/fun_with_flags/config_test.exs
@@ -68,20 +68,14 @@ defmodule FunWithFlags.ConfigTest do
     end
 
     test "with flutter" do
-      # enable flutter
-      Mix.Config.persist(fun_with_flags: [cache: [flutter: true]])
+      # enable flutter and customize TTL
+      Mix.Config.persist(fun_with_flags: [cache: [flutter: true, ttl: 50]])
 
-      # collect 100 ttls
-      ttls = Enum.map(0..100, fn _ ->
-        Config.cache_ttl
-      end)
+      # seed RNG and collect TTLs
+      :rand.seed(:exsplus, {101, 102, 103})
+      ttls = Enum.map(0..5, fn _ -> Config.cache_ttl end)
 
-      # test that the values aren't all the same
-      # this test isn't ideal because 1, it's technically non-deterministic and,
-      # 2, it only checks that the values aren't _all_ the same.  If there were
-      # only 2 unique values, this would pass.  That said, I think it's sufficient
-      # when considering the implementation and the pitfalls of using random numbers
-      assert length(Enum.uniq(ttls)) > 1
+      assert [49, 51, 47, 45, 51, 48] = ttls
 
       # cleanup
       reset_cache_defaults()

--- a/test/fun_with_flags/flag_test.exs
+++ b/test/fun_with_flags/flag_test.exs
@@ -1,5 +1,6 @@
 defmodule FunWithFlags.FlagTest do
   use FunWithFlags.TestCase, async: true
+  import FunWithFlags.TestUtils
 
   alias FunWithFlags.{Flag,Gate}
 
@@ -351,7 +352,7 @@ defmodule FunWithFlags.FlagTest do
       #    - percentage_of_time (if present, applies with or without actors in the enabled?() call)
       #   or:
       #    - percentage_of_actors (only if an actor is provided)
-    
+
       # score with :warging flag = 0.122283935546875
       other_actor = %{actor_id: "a valid actor, but not an enabled one"}
 
@@ -489,6 +490,30 @@ defmodule FunWithFlags.FlagTest do
       ]}
 
       assert Flag.enabled?(flag, for: item)
+    end
+  end
+
+  describe "flutter_offset" do
+    test "returned offset is <= 0" do
+      Enum.each(0..100, fn _ ->
+        flag = %Flag{name: unique_atom()}
+
+        assert Flag.flutter_offset(flag) <= 0
+      end)
+    end
+
+    test "offset is never > 10% of the TTL" do
+      ttl = 100
+      Mix.Config.persist(fun_with_flags: [cache: [ttl: ttl]])
+
+      Enum.each(0..100, fn _ ->
+        flag = %Flag{name: unique_atom()}
+
+        assert abs(Flag.flutter_offset(flag)) <= (ttl * 0.1)
+      end)
+
+      # cleanup
+      Mix.Config.persist(fun_with_flags: [cache: [ttl: 60]])
     end
   end
 end

--- a/test/fun_with_flags/timestamps_test.exs
+++ b/test/fun_with_flags/timestamps_test.exs
@@ -25,7 +25,7 @@ defmodule FunWithFlags.TimestampsTest do
   end
 
 
-  describe "expired?() tells if a timestamp is past its ttl" do    
+  describe "expired?() tells if a timestamp is past its ttl" do
     test "it returns true when the timestamp is expired" do
       one_min_ago = TS.now - 60
       assert TS.expired?(one_min_ago, 10)
@@ -36,6 +36,12 @@ defmodule FunWithFlags.TimestampsTest do
       one_min_ago = TS.now - 60
       refute TS.expired?(one_min_ago, 61)
       refute TS.expired?(one_min_ago, 3600)
+    end
+
+    test "it accounts for flutter offset" do
+      one_min_ago = TS.now - 60
+      refute TS.expired?(one_min_ago, 61, 2)
+      assert TS.expired?(one_min_ago, 59, -2)
     end
   end
 end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -47,7 +47,7 @@ defmodule FunWithFlags.TestUtils do
   end
 
 
-  
+
   defmacro timetravel([by: offset], [do: body]) do
     quote do
       fake_now = FunWithFlags.Timestamps.now + unquote(offset)
@@ -61,6 +61,9 @@ defmodule FunWithFlags.TestUtils do
         end,
         expired?: fn(timestamp, ttl) ->
           :meck.passthrough([timestamp, ttl])
+        end,
+        expired?: fn(timestamp, ttl, offset) ->
+          :meck.passthrough([timestamp, ttl, offset])
         end
       ]) do
         unquote(body)


### PR DESCRIPTION
This is in response to the TODO item of "Add some optional randomness to the TTL".  I'm open to different naming suggestions.

This PR adds a deterministic negative offset to the TTL for a flag.  This offset is computed based off the flag's name, is always < 10% of the TTL, and is always negative so the TTL becomes the _maximum_ life of a flag in cache.

This may seem like a strange approach, but I ran into some trouble with introduction of a purely random offset ([example here](https://github.com/kieraneglin/fun_with_flags/blob/ttl-flutter/lib/fun_with_flags/config.ex#L42)).  With an approach like this, rapid attempts to read the cache (and therefor rapid checking of expiration while considering a random offset) would tend to expire the cache at the lower bound of the offset, defeating the purpose.  This also gets messy when the TTL is saved as a module attribute (`@ttl Config.cache_ttl`), since that gets locked in at compile time and removes any randomness.