### PR TITLE
Improve Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,6 @@ elixir:
 otp_release:
   - 22.2
   - 21.2 # 21.3 no longer available on Travis
-env:
-  - CACHE_ENABLED=true  PERSISTENCE=ecto RDBMS=postgres PUBSUB_BROKER=phoenix_pubsub TEST_OPTS='--no-start --exclude redis_pubsub --exclude redis_persistence --exclude phoenix_pubsub:with_redis --include phoenix_pubsub:with_ecto --include phoenix_pubsub:true --include ecto_persistence'
-  - CACHE_ENABLED=false PERSISTENCE=ecto RDBMS=postgres PUBSUB_BROKER=phoenix_pubsub TEST_OPTS='--no-start --only integration'
-  - CACHE_ENABLED=true  PERSISTENCE=ecto RDBMS=mysql PUBSUB_BROKER=phoenix_pubsub TEST_OPTS='--no-start --exclude redis_pubsub --exclude redis_persistence --exclude phoenix_pubsub:with_redis --include phoenix_pubsub:with_ecto --include phoenix_pubsub:true --include ecto_persistence'
-  - CACHE_ENABLED=false PERSISTENCE=ecto RDBMS=mysql PUBSUB_BROKER=phoenix_pubsub TEST_OPTS='--no-start --only integration'
-  - CACHE_ENABLED=true  PERSISTENCE=redis TEST_OPTS='--exclude phoenix_pubsub --exclude ecto_persistence'
-  - CACHE_ENABLED=false PERSISTENCE=redis TEST_OPTS='--only integration'
-  - CACHE_ENABLED=true  PERSISTENCE=redis PUBSUB_BROKER=phoenix_pubsub TEST_OPTS='--no-start --exclude redis_pubsub --exclude ecto_persistence --exclude phoenix_pubsub:with_ecto --include phoenix_pubsub:with_redis --include phoenix_pubsub:true'
-  - CACHE_ENABLED=false PERSISTENCE=redis PUBSUB_BROKER=phoenix_pubsub TEST_OPTS='--no-start --only integration'
 matrix:
   exclude:
     - elixir: 1.7
@@ -30,7 +21,7 @@ before_script:
   - MIX_ENV=test mix ecto.create
   - MIX_ENV=test mix ecto.migrate
 script:
-  - mix test --force $TEST_OPTS
+  - mix test.all
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,12 @@ services:
   - postgresql
   - mysql
 before_script:
-  - MIX_ENV=test mix compile --warnings-as-errors # Compile once.
-  - MIX_ENV=test mix ecto.create
-  - MIX_ENV=test mix ecto.migrate
+  - MIX_ENV=test PERSISTENCE=ecto RDBMS=postgres mix compile --warnings-as-errors
+  - MIX_ENV=test PERSISTENCE=ecto RDBMS=postgres mix do ecto.create, ecto.migrate
+  - rm -rf _build/test/lib/fun_with_flag
+  - MIX_ENV=test PERSISTENCE=ecto RDBMS=mysql mix compile --warnings-as-errors
+  - MIX_ENV=test PERSISTENCE=ecto RDBMS=mysql mix do ecto.create, ecto.migrate
+  - rm -rf _build/test/lib/fun_with_flags
 script:
   - mix test.all
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ services:
 before_script:
   - MIX_ENV=test PERSISTENCE=ecto RDBMS=postgres mix compile --warnings-as-errors
   - MIX_ENV=test PERSISTENCE=ecto RDBMS=postgres mix do ecto.create, ecto.migrate
-  - rm -rf _build/test/lib/fun_with_flag
+  - rm -rf _build/test/lib/fun_with_flags
   - MIX_ENV=test PERSISTENCE=ecto RDBMS=mysql mix compile --warnings-as-errors
   - MIX_ENV=test PERSISTENCE=ecto RDBMS=mysql mix do ecto.create, ecto.migrate
   - rm -rf _build/test/lib/fun_with_flags

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -20,7 +20,6 @@ end
 # we want to start the Phoenix.PubSub process before starting the application.
 Application.ensure_all_started(:fun_with_flags)
 IO.puts "--------------------------------------------------------------"
-IO.puts "$TEST_OPTS='#{System.get_env("TEST_OPTS")}'"
 IO.puts "$CACHE_ENABLED=#{System.get_env("CACHE_ENABLED")}"
 IO.puts "$PERSISTENCE=#{System.get_env("PERSISTENCE")}"
 IO.puts "$RDBMS=#{System.get_env("RDBMS")}"


### PR DESCRIPTION
Run fewer travis jobs per build, with more test configurations per job.

This should be faster as the env setup (OS, runtime, dependencies, DB migrations, etc) has to be done fewer times.