### PR TITLE
Remove ecto repo compiled config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.6.0 (unreleased)
 
 * Add support for Elixir 1.11. Drop support for Elixir 1.7. Elixir >= 1.8 is now required. Dropping support for older versions of Elixir simply means that this package is no longer tested with them in CI, and that compatibility issues are not considered bugs.
+* More internal changes to not compile in the package configuration. Removed compile-time referneces to the Ecto repo and the Ecto table name. See the release notes for v1.5.1 (below) for more details on this type of changes.
 * Dev and test fixes to support Phoenix.PubSub on OTP 23 and Elixir >= 1.10.3. This was only an issue when working locally, and there should be no problems when using the previous version of the package in a host application.
 * Update Redix to 1.0. As [its changelog](https://github.com/whatyouhide/redix/blob/main/CHANGELOG.md#v100) says this doesn't introduce breaking changes, but it's a major version bump that should be documented here, as it will require changes in the host applications mix files.
 

--- a/lib/fun_with_flags/store/persistent/ecto.ex
+++ b/lib/fun_with_flags/store/persistent/ecto.ex
@@ -5,17 +5,16 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
 
   @behaviour FunWithFlags.Store.Persistent
 
-  alias FunWithFlags.{Config, Gate}
+  alias FunWithFlags.Gate
   alias FunWithFlags.Store.Persistent.Ecto.Record
   alias FunWithFlags.Store.Serializer.Ecto, as: Serializer
 
-  import FunWithFlags.Config, only: [ecto_repo: 0]
+  import FunWithFlags.Config, only: [ecto_repo: 0, ecto_table_name: 0]
   import Ecto.Query
 
   require Logger
 
   @mysql_lock_timeout_s 3
-  @table_name Config.ecto_table_name()
 
 
   @impl true
@@ -223,7 +222,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
   defp postgres_table_lock! do
     Ecto.Adapters.SQL.query!(
       ecto_repo(),
-      "LOCK TABLE #{@table_name} IN SHARE ROW EXCLUSIVE MODE;"
+      "LOCK TABLE #{ecto_table_name()} IN SHARE ROW EXCLUSIVE MODE;"
     )
   end
 


### PR DESCRIPTION
More work similar to what was done in https://github.com/tompave/fun_with_flags/pull/79.

I need to run some benchmarks before merging this, and understand how it would impact the work I'm doing on the config overhaul for v2.

As things stand now, this is not really fixing a bug, just removing some compilation warnings.