### PR TITLE
Postgres lock improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add support for Elixir 1.11. Drop support for Elixir 1.7. Elixir >= 1.8 is now required. Dropping support for older versions of Elixir simply means that this package is no longer tested with them in CI, and that compatibility issues are not considered bugs.
 * More internal changes to not compile in the package configuration. Removed compile-time referneces to the Ecto repo and the Ecto table name. See the release notes for v1.5.1 (below) for more details on this type of changes.
+* Ecto and Postgres persistence: when updating percentage gates, use a flag-scoped advisory lock rathen than locking the entire table. With the old system the entire table was locked when setting or changing any percentage gate, across all flags. With this change, the lock is scoped to one flag and the table is never fully locked.
 * Dev and test fixes to support Phoenix.PubSub on OTP 23 and Elixir >= 1.10.3. This was only an issue when working locally, and there should be no problems when using the previous version of the package in a host application.
 * Update Redix to 1.0. As [its changelog](https://github.com/whatyouhide/redix/blob/main/CHANGELOG.md#v100) says this doesn't introduce breaking changes, but it's a major version bump that should be documented here, as it will require changes in the host applications mix files.
 

--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ For example, if we have two or more nodes running the application, and on one of
 FunWithFlags uses three mechanisms to deal with the problem:
 
 1. Use PubSub to emit change notifications. All nodes subscribe to the same channel and reload flags in the ETS cache when required.
-2. If that fails, the cache has a configurable TTL. Reading from redis every few minutes is still better than doing so 30k times per second.
+2. If that fails, the cache has a configurable TTL. Reading from the DB every few minutes is still better than doing so 30k times per second.
 3. If that doesn't work, it's possible to disable the cache and just read from the DB all the time. That's what Flipper does.
 
 In terms of performance, very synthetic benchmarks (where the DBs run on the same machine as the Beam code, so with no network hop but sharing the CPU) show that the ETS cache makes querying the FunWithFlags interface between 10 and 20 times faster than going directly to Redis, and between 20 and 40 times faster than going directly to Postgres. The variance depends on the complexity of the flag data to be retrieved.

--- a/lib/fun_with_flags/store/persistent/ecto.ex
+++ b/lib/fun_with_flags/store/persistent/ecto.ex
@@ -51,8 +51,8 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
     repo = ecto_repo()
 
     transaction_fn = case db_type(repo) do
-      :postgres -> &_transaction_with_lock_postgres/2
-      :mysql -> &_transaction_with_lock_mysql/2
+      :postgres -> &transaction_with_lock_postgres/2
+      :mysql -> &transaction_with_lock_mysql/2
     end
 
     out = transaction_fn.(repo, fn() ->
@@ -91,14 +91,14 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
   end
 
 
-  defp _transaction_with_lock_postgres(repo, upsert_fn) do
+  defp transaction_with_lock_postgres(repo, upsert_fn) do
     repo.transaction fn() ->
       postgres_table_lock!(repo)
       upsert_fn.()
     end
   end
 
-  defp _transaction_with_lock_mysql(repo, upsert_fn) do
+  defp transaction_with_lock_mysql(repo, upsert_fn) do
     repo.transaction fn() ->
       if mysql_lock!(repo) do
         try do

--- a/lib/fun_with_flags/store/persistent/ecto.ex
+++ b/lib/fun_with_flags/store/persistent/ecto.ex
@@ -9,7 +9,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
   alias FunWithFlags.Store.Persistent.Ecto.Record
   alias FunWithFlags.Store.Serializer.Ecto, as: Serializer
 
-  import FunWithFlags.Config, only: [ecto_repo: 0, ecto_table_name: 0]
+  import FunWithFlags.Config, only: [ecto_repo: 0]
   import Ecto.Query
 
   require Logger
@@ -51,7 +51,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
     repo = ecto_repo()
 
     transaction_fn = case db_type(repo) do
-      :postgres -> &transaction_with_lock_postgres/2
+      :postgres -> build_transaction_with_lock_postgres_fn(flag_name)
       :mysql -> &transaction_with_lock_mysql/2
     end
 
@@ -91,13 +91,23 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
   end
 
 
-  defp transaction_with_lock_postgres(repo, upsert_fn) do
-    repo.transaction fn() ->
-      postgres_table_lock!(repo)
-      upsert_fn.()
+  # Returns a transaction-wrapper function for Postgres.
+  #
+  defp build_transaction_with_lock_postgres_fn(flag_name) do
+    fn(repo, upsert_fn) ->
+      repo.transaction fn() ->
+        Ecto.Adapters.SQL.query!(repo,
+          "SELECT pg_advisory_xact_lock(hashtext('fun_with_flags_percentage_gate_upsert'), hashtext($1))",
+          [to_string(flag_name)]
+        )
+        upsert_fn.()
+      end
     end
   end
 
+
+  # Is itself a transaction-wrapper function for MySQL.
+  #
   defp transaction_with_lock_mysql(repo, upsert_fn) do
     repo.transaction fn() ->
       if mysql_lock!(repo) do
@@ -219,14 +229,6 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
 
   defp deserialize(flag_name, records) do
     Serializer.deserialize_flag(flag_name, records)
-  end
-
-
-  defp postgres_table_lock!(repo) do
-    Ecto.Adapters.SQL.query!(
-      repo,
-      "LOCK TABLE #{ecto_table_name()} IN SHARE ROW EXCLUSIVE MODE;"
-    )
   end
 
 


### PR DESCRIPTION
When updating a percentage gate, acquire a lock with `SELECT pg_advisory_xact_lock(key_1, key_2)`, rather than `LOCK table ...`.