### PR TITLE
Notifications into the supervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ config :fun_with_flags, :cache_bust_notifications,
 Or, without Phoenix:
 
 ```elixir
-# possibly in the application's supervision tree
+# possibly in the application's supervision tree, alternatively specified below
 children = [
   {Phoenix.PubSub, [name: :my_pubsub_process_name, adapter: Phoenix.PubSub.PG2]}
 ]
@@ -597,6 +597,9 @@ config :fun_with_flags, :cache_bust_notifications,
   enabled: true,
   adapter: FunWithFlags.Notifications.PhoenixPubSub,
   client: :my_pubsub_process_name
+  # pubsub_driver: Phoenix.PubSub.PG2 (optional)
+  # pubsub_driver: {Phoenix.PubSub.PG2, pool_size: 10} (optional with options)
+
 ```
 
 ## Installation

--- a/lib/fun_with_flags/config.ex
+++ b/lib/fun_with_flags/config.ex
@@ -13,7 +13,8 @@ defmodule FunWithFlags.Config do
 
   @default_notifications_config [
     enabled: true,
-    adapter: FunWithFlags.Notifications.Redis
+    adapter: FunWithFlags.Notifications.Redis,
+    pubsub_driver: Phoenix.PubSub.PG2
   ]
 
   @default_persistence_config [
@@ -106,6 +107,9 @@ defmodule FunWithFlags.Config do
     Keyword.get(notifications_config(), :adapter)
   end
 
+  def notifications_pubsub_driver do
+    Keyword.get(notifications_config(), :pubsub_driver)
+  end
 
   def phoenix_pubsub? do
     notifications_adapter() == FunWithFlags.Notifications.PhoenixPubSub

--- a/lib/fun_with_flags/notifications/phoenix_pubsub.ex
+++ b/lib/fun_with_flags/notifications/phoenix_pubsub.ex
@@ -19,6 +19,15 @@ defmodule FunWithFlags.Notifications.PhoenixPubSub do
     }
   end
 
+  def pubsub_worker_spec(driver, name, opts \\ []) do
+    %{
+      id: :driver,
+      start: {driver, :start_link, [opts |> Keyword.merge([name: name])]},
+      restart: :permanent,
+      type: :worker
+    }
+  end
+
 
   # Initialize the GenServer with a unique id (binary).
   # This id will stay with the GenServer until it's terminated, and is


### PR DESCRIPTION
Would fix #31 

This puts the phoenix pubsub into the fun with flags supervisor.  That means both of the pubsub related applications start up at roughly the same time, regardless of what your own application does.

It also means you don't have to configure the phoenix pubsub module into your supervision tree, or even specify it in the fun with flags cache busting config (it defaults to an obvious choice).  You can supply options to phoenix pub sub pretty easily, and for people who don't want to do this, the old option still works.

This would break people who have put the pubsub process into their own supervision tree, not sure what to do about that.  I also am not using phoenix, so not totally sure that works but it probably does.  This is probably pretty close to a solution if you have any feedback.