### PR TITLE
Improve control over the start behaviour

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -5,6 +5,7 @@ alias FunWithFlags.{Actor,Group}
 
 alias FunWithFlags.Dev.EctoRepo, as: Repo
 alias FunWithFlags.Store.Persistent.Ecto.Record
+alias FunWithFlags.Supervisor, as: Sup
 
 
 # When calling `respawn` in a iex session, e.g. debugging tests,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Addressed all dialyzer warnings. Fixed some incorrect typespecs and simplified the implementation of some functions.
 * Miscellaneous documentation fixes and improvements. (Thanks [kianmeng](https://github.com/kianmeng), [pull/89](https://github.com/tompave/fun_with_flags/pull/89) and [pull/90](https://github.com/tompave/fun_with_flags/pull/90).)
 * Documented the `FunWithFlags.Store.Cache` module, and its `Cache.flush/0` and `Cache.dump/0` functions. They're now part of the public API of the package.
-* Introduced a new `FunWithFlags.Supervisor` module to manage the supervision tree for the package. The supervision strategy and configuration are unchanged, and host applications don't need to do anything to upgrade. However, this module is part of the public API of the package and can be used to better control the start behaviour of FunWithFlags.
+* Introduced a new `FunWithFlags.Supervisor` module to manage the supervision tree for the package. The supervision strategy and configuration are unchanged, and host applications don't need to do anything to upgrade. However, this module is part of the public API of the package and can be used to better control the start behaviour of FunWithFlags. This has also been documented [in a new section of the readme](https://github.com/tompave/fun_with_flags/tree/custom_start#application-start-behaviour).
 
 ## v1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Addressed all dialyzer warnings. Fixed some incorrect typespecs and simplified the implementation of some functions.
 * Miscellaneous documentation fixes and improvements. (Thanks [kianmeng](https://github.com/kianmeng), [pull/89](https://github.com/tompave/fun_with_flags/pull/89) and [pull/90](https://github.com/tompave/fun_with_flags/pull/90).)
 * Documented the `FunWithFlags.Store.Cache` module, and its `Cache.flush/0` and `Cache.dump/0` functions. They're now part of the public API of the package.
-* Introduced a new `FunWithFlags.Supervisor` module to manage the supervision tree for the package. The supervision strategy and configuration are unchanged, and host applications don't need to do anything to upgrade. However, this module is part of the public API of the package and can be used to better control the start behaviour of FunWithFlags. This has also been documented [in a new section of the readme](https://github.com/tompave/fun_with_flags/tree/custom_start#application-start-behaviour).
+* Introduced a new `FunWithFlags.Supervisor` module to manage the supervision tree for the package. The supervision strategy and configuration are unchanged, and host applications don't need to do anything to upgrade. However, this module is part of the public API of the package and can be used to better control the start behaviour of FunWithFlags. This has also been documented [in a new section of the readme](https://github.com/tompave/fun_with_flags#application-start-behaviour).
 
 ## v1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Addressed all dialyzer warnings. Fixed some incorrect typespecs and simplified the implementation of some functions.
 * Miscellaneous documentation fixes and improvements. (Thanks [kianmeng](https://github.com/kianmeng), [pull/89](https://github.com/tompave/fun_with_flags/pull/89) and [pull/90](https://github.com/tompave/fun_with_flags/pull/90).)
 * Documented the `FunWithFlags.Store.Cache` module, and its `Cache.flush/0` and `Cache.dump/0` functions. They're now part of the public API of the package.
+* Introduced a new `FunWithFlags.Supervisor` module to manage the supervision tree for the package. The supervision strategy and configuration are unchanged, and host applications don't need to do anything to upgrade. However, this module is part of the public API of the package and can be used to better control the start behaviour of FunWithFlags.
 
 ## v1.6.0
 

--- a/README.md
+++ b/README.md
@@ -685,14 +685,14 @@ defmodule MyPhoenixApp.Application do
 
 Then it's necessary to configure the Mix project to not start the `:fun_with_flags` application automatically. This can be accomplished in the Mixfile in a number of ways, for example: (**Note**: These are alternative solutions, you don't need to do both. You must decide which is more appropriate for your setup.)
 
-* Declare the `:fun_with_flags` dependency with either the `runtime: false` or `app: false` options. ([docs](https://hexdocs.pm/mix/1.11.3/Mix.Tasks.Deps.html#module-dependency-definition-options))
+* **Option A**: Declare the `:fun_with_flags` dependency with either the `runtime: false` or `app: false` options. ([docs](https://hexdocs.pm/mix/1.11.3/Mix.Tasks.Deps.html#module-dependency-definition-options))
 
 ```diff
 - {:fun_with_flags, "~> 1.6"},
 + {:fun_with_flags, "~> 1.6", runtime: false},
 ```
 
-* Declare that the `:fun_with_flags` application is managed directly by your host application ([docs](https://hexdocs.pm/mix/1.11.3/Mix.Tasks.Compile.App.html)).
+* **Option B**: Declare that the `:fun_with_flags` application is managed directly by your host application ([docs](https://hexdocs.pm/mix/1.11.3/Mix.Tasks.Compile.App.html)).
 
 ```diff
   def application do
@@ -706,7 +706,7 @@ Then it's necessary to configure the Mix project to not start the `:fun_with_fla
 
 The result of those changes is that the `:fun_with_flags` application won't be loaded and started automatically, and therefore the FunWithFlags supervision tree won't risk to be started before the other processes in the host Phoenix application. Rather, the supervision tree will start alongside the other core Phoenix processes.
 
-One final note on this topic is that if you're also using [`FunWithFlags.UI`](https://github.com/tompave/fun_with_flags_ui) (refer to the [Web Dashboard](#web-dashboard) section, above in this document), then that will need to be configured as well. The reason is that `:fun_with_flags` is a dependency of `:fun_with_flags_ui`, so including the latter as a dependency will cause the former to be auto-started despite the configuration described above. To avoid this, the same configuration should be used for the `:fun_with_flags_ui` dependency, regardless of the approach used (`runtime: false`, `app: false`, or `included_applications`).
+One final note on this topic is that if you're also using [`FunWithFlags.UI`](https://github.com/tompave/fun_with_flags_ui) (refer to the [Web Dashboard](#web-dashboard) section, above in this document), then that will need to be configured as well. The reason is that `:fun_with_flags` is a dependency of `:fun_with_flags_ui`, so including the latter as a dependency will cause the former to be auto-started despite the configuration described above. To avoid this, the same configuration should be used for the `:fun_with_flags_ui` dependency, regardless of the approach used (Option A: `runtime: false`, `app: false`; or Option B: `included_applications`).
 
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -688,8 +688,8 @@ Then it's necessary to configure the Mix project to not start the `:fun_with_fla
 * Declare the `:fun_with_flags` dependency with either the `runtime: false` or `app: false` options. ([docs](https://hexdocs.pm/mix/1.11.3/Mix.Tasks.Deps.html#module-dependency-definition-options))
 
 ```diff
-+ {:fun_with_flags, "~> 1.6"},
-- {:fun_with_flags, "~> 1.6", runtime: false},
+- {:fun_with_flags, "~> 1.6"},
++ {:fun_with_flags, "~> 1.6", runtime: false},
 ```
 
 * Declare that the `:fun_with_flags` application is managed directly by your host application ([docs](https://hexdocs.pm/mix/1.11.3/Mix.Tasks.Compile.App.html)).

--- a/lib/fun_with_flags/application.ex
+++ b/lib/fun_with_flags/application.ex
@@ -2,54 +2,8 @@ defmodule FunWithFlags.Application do
   @moduledoc false
 
   use Application
-  alias FunWithFlags.Config
-  require Logger
 
   def start(_type, _args) do
-    opts = [strategy: :one_for_one, name: FunWithFlags.Supervisor]
-    Supervisor.start_link(children(), opts)
-  end
-
-
-  defp children do
-    [
-      FunWithFlags.Store.Cache.worker_spec(),
-      persistence_spec(),
-      notifications_spec(),
-    ]
-    |> Enum.reject(&(!&1))
-  end
-
-
-  defp persistence_spec do
-    adapter = Config.persistence_adapter()
-
-    try do
-      adapter.worker_spec()
-    rescue
-      e in [UndefinedFunctionError] ->
-        Logger.error "FunWithFlags: It looks like you're trying to use #{inspect(adapter)} " <>
-         "to persist flags, but you haven't added its optional dependency to the Mixfile " <>
-         "of your project."
-        reraise e, __STACKTRACE__
-    end
-  end
-
-  # If the change notifications are enabled AND the adapter can
-  # be supervised, then return a spec for the supervisor.
-  # Also handle cases where an adapter has been configured but its
-  # optional dependency is not required in the Mixfile.
-  #
-  defp notifications_spec do
-    try do
-      Config.change_notifications_enabled? && Config.notifications_adapter.worker_spec()
-    rescue
-      e in [UndefinedFunctionError] ->
-        Logger.error "FunWithFlags: It looks like you're trying to use #{inspect(Config.notifications_adapter)} " <>
-         "for the cache-busting notifications, but you haven't added its optional dependency to the Mixfile " <>
-         "of your project. If you don't need cache-busting notifications, they can be disabled to make this " <>
-         "error go away."
-        reraise e, __STACKTRACE__
-    end
+    FunWithFlags.Supervisor.start_link(nil)
   end
 end

--- a/lib/fun_with_flags/config.ex
+++ b/lib/fun_with_flags/config.ex
@@ -48,7 +48,7 @@ defmodule FunWithFlags.Config do
   end
 
 
-  defp ets_cache_config do
+  def ets_cache_config do
     Keyword.merge(
       @default_cache_config,
       Application.get_env(:fun_with_flags, :cache, [])

--- a/lib/fun_with_flags/supervisor.ex
+++ b/lib/fun_with_flags/supervisor.ex
@@ -14,6 +14,9 @@ defmodule FunWithFlags.Supervisor do
   when FunWithFlag's supervision tree is started. This is helpful when the
   package is configured to depend on some of the host application's modules, e.g.
   the `Phoenix.PubSub` process ([as documented](readme.html#pubsub-adapters)).
+
+  More detailed instructions on how to configure this in an application are
+  available in the [readme](readme.html#application-start-behaviour).
   """
 
   alias FunWithFlags.Config

--- a/lib/fun_with_flags/supervisor.ex
+++ b/lib/fun_with_flags/supervisor.ex
@@ -1,22 +1,32 @@
 defmodule FunWithFlags.Supervisor do
   @moduledoc """
-  Implements `Supervisor.child_spec/1` to describe the supervision tree for the
+  A [Module-based supervisor](https://hexdocs.pm/elixir/Supervisor.html#module-module-based-supervisors).
+
+  It implements [`Supervisor.child_spec/1`](https://hexdocs.pm/elixir/Supervisor.html#module-child_spec-1) to describe the supervision tree for the
   `:fun_with_flags` application.
 
-  This module is used internally by the package when the application starts its
-  own supervision tree (the default). If that is disabled, the host applcation
-  should use this module to start the supervision tree directly.
+  This module is used internally by the package when the `:fun_with_flags` OTP
+  application starts its own supervision tree, which is the default behavior.
+  If that is disabled, the user's host applcation should use this module to start
+  the supervision tree directly.
+
+  The main purpose of this API is allow the user's host application to control
+  when FunWithFlag's supervision tree is started. This is helpful when the
+  package is configured to depend on some of the host application's modules, e.g.
+  the `Phoenix.PubSub` process ([as documented](readme.html#pubsub-adapters)).
   """
 
   alias FunWithFlags.Config
   require Logger
 
-  # Automatically defines child_spec/1.
+  # Automatically defines `child_spec/1`.
   use Supervisor
 
+  @doc """
+  How to start this supervisor and its tree.
 
-  # Requited because of the `child_spec/2` definition injected by `use Supervisor`.
-  #
+  This function is referenced by the `child_spec/1` definition for this supervisor module.
+  """
   def start_link(init_arg) do
     Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
   end

--- a/lib/fun_with_flags/supervisor.ex
+++ b/lib/fun_with_flags/supervisor.ex
@@ -1,0 +1,72 @@
+defmodule FunWithFlags.Supervisor do
+  @moduledoc """
+  Implements `Supervisor.child_spec/1` to describe the supervision tree for the
+  `:fun_with_flags` application.
+
+  This module is used internally by the package when the application starts its
+  own supervision tree (the default). If that is disabled, the host applcation
+  should use this module to start the supervision tree directly.
+  """
+
+  alias FunWithFlags.Config
+  require Logger
+
+  # Automatically defines child_spec/1.
+  use Supervisor
+
+
+  # Requited because of the `child_spec/2` definition injected by `use Supervisor`.
+  #
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+
+  @impl true
+  def init(_init_arg) do
+    Supervisor.init(children(), strategy: :one_for_one)
+  end
+
+
+  defp children do
+    [
+      FunWithFlags.Store.Cache.worker_spec(),
+      persistence_spec(),
+      notifications_spec(),
+    ]
+    |> Enum.reject(&(!&1))
+  end
+
+
+  defp persistence_spec do
+    adapter = Config.persistence_adapter()
+
+    try do
+      adapter.worker_spec()
+    rescue
+      e in [UndefinedFunctionError] ->
+        Logger.error "FunWithFlags: It looks like you're trying to use #{inspect(adapter)} " <>
+         "to persist flags, but you haven't added its optional dependency to the Mixfile " <>
+         "of your project."
+        reraise e, __STACKTRACE__
+    end
+  end
+
+  # If the change notifications are enabled AND the adapter can
+  # be supervised, then return a spec for the supervisor.
+  # Also handle cases where an adapter has been configured but its
+  # optional dependency is not required in the Mixfile.
+  #
+  defp notifications_spec do
+    try do
+      Config.change_notifications_enabled? && Config.notifications_adapter.worker_spec()
+    rescue
+      e in [UndefinedFunctionError] ->
+        Logger.error "FunWithFlags: It looks like you're trying to use #{inspect(Config.notifications_adapter)} " <>
+         "for the cache-busting notifications, but you haven't added its optional dependency to the Mixfile " <>
+         "of your project. If you don't need cache-busting notifications, they can be disabled to make this " <>
+         "error go away."
+        reraise e, __STACKTRACE__
+    end
+  end
+end

--- a/test/fun_with_flags/supervisor_test.exs
+++ b/test/fun_with_flags/supervisor_test.exs
@@ -1,0 +1,217 @@
+defmodule FunWithFlags.SupervisorTest do
+  use FunWithFlags.TestCase, async: false
+
+  alias FunWithFlags.Config
+
+  test "the auto-generated child_spec/1" do
+    expected = %{
+      id: FunWithFlags.Supervisor,
+      start: {FunWithFlags.Supervisor, :start_link, [nil]},
+      type: :supervisor
+    }
+
+    assert ^expected = FunWithFlags.Supervisor.child_spec(nil)
+  end
+
+  describe "initializing the config for the children" do
+    @tag :redis_persistence
+    @tag :redis_pubsub
+    test "with Redis persistence and Redis PubSub" do
+      expected = {
+        :ok,
+        {
+          %{intensity: 3, period: 5, strategy: :one_for_one},
+          [
+            %{
+              id: FunWithFlags.Store.Cache,
+              restart: :permanent,
+              start: {FunWithFlags.Store.Cache, :start_link, []},
+              type: :worker
+            },
+            %{
+              id: Redix,
+              start: {Redix, :start_link,
+               [
+                 [
+                   host: "localhost",
+                   port: 6379,
+                   database: 5,
+                   name: FunWithFlags.Store.Persistent.Redis,
+                   sync_connect: false
+                 ]
+               ]},
+              type: :worker
+            },
+            %{
+              id: FunWithFlags.Notifications.Redis,
+              restart: :permanent,
+              start: {FunWithFlags.Notifications.Redis, :start_link, []},
+              type: :worker
+            }
+          ]
+        }
+      }
+
+      assert ^expected = FunWithFlags.Supervisor.init(nil)
+    end
+
+    @tag :redis_persistence
+    @tag :phoenix_pubsub
+    test "with Redis persistence and Phoenix PubSub" do
+      expected = {
+        :ok,
+        {
+          %{intensity: 3, period: 5, strategy: :one_for_one},
+          [
+            %{
+              id: FunWithFlags.Store.Cache,
+              restart: :permanent,
+              start: {FunWithFlags.Store.Cache, :start_link, []},
+              type: :worker
+            },
+            %{
+              id: Redix,
+              start: {Redix, :start_link,
+               [
+                 [
+                   host: "localhost",
+                   port: 6379,
+                   database: 5,
+                   name: FunWithFlags.Store.Persistent.Redis,
+                   sync_connect: false
+                 ]
+               ]},
+              type: :worker
+            },
+            %{
+              id: FunWithFlags.Notifications.PhoenixPubSub,
+              restart: :permanent,
+              start: {FunWithFlags.Notifications.PhoenixPubSub, :start_link, []},
+              type: :worker
+            }
+          ]
+        }
+      }
+
+      assert ^expected = FunWithFlags.Supervisor.init(nil)
+    end
+
+    @tag :ecto_persistence
+    @tag :phoenix_pubsub
+    test "with Ecto persistence and Phoenix PubSub" do
+      expected = {
+        :ok,
+        {
+          %{intensity: 3, period: 5, strategy: :one_for_one},
+          [
+            %{
+              id: FunWithFlags.Store.Cache,
+              restart: :permanent,
+              start: {FunWithFlags.Store.Cache, :start_link, []},
+              type: :worker
+            },
+            %{
+              id: FunWithFlags.Notifications.PhoenixPubSub,
+              restart: :permanent,
+              start: {FunWithFlags.Notifications.PhoenixPubSub, :start_link, []},
+              type: :worker
+            }
+          ]
+        }
+      }
+
+      assert ^expected = FunWithFlags.Supervisor.init(nil)
+    end
+  end
+
+
+  describe "initializing the config for the children (no cache)" do
+    setup do
+      # Capture the original cache config
+      original_cache_config = Config.ets_cache_config()
+
+      # Disable the cache for these tests.
+      Mix.Config.persist(fun_with_flags: [cache: [
+        enabled: false, ttl: original_cache_config[:ttl]
+      ]])
+
+      # Restore the orignal config
+      on_exit fn ->
+        Mix.Config.persist(fun_with_flags: [cache: original_cache_config])
+        assert ^original_cache_config = Config.ets_cache_config()
+      end
+    end
+
+    @tag :redis_persistence
+    @tag :redis_pubsub
+    test "with Redis persistence and Redis PubSub, no cache" do
+      expected = {
+        :ok,
+        {
+          %{intensity: 3, period: 5, strategy: :one_for_one},
+          [
+            %{
+              id: Redix,
+              start: {Redix, :start_link,
+               [
+                 [
+                   host: "localhost",
+                   port: 6379,
+                   database: 5,
+                   name: FunWithFlags.Store.Persistent.Redis,
+                   sync_connect: false
+                 ]
+               ]},
+              type: :worker
+            }
+          ]
+        }
+      }
+
+      assert ^expected = FunWithFlags.Supervisor.init(nil)
+    end
+
+    @tag :redis_persistence
+    @tag :phoenix_pubsub
+    test "with Redis persistence and Phoenix PubSub, no cache" do
+      expected = {
+        :ok,
+        {
+          %{intensity: 3, period: 5, strategy: :one_for_one},
+          [
+            %{
+              id: Redix,
+              start: {Redix, :start_link,
+               [
+                 [
+                   host: "localhost",
+                   port: 6379,
+                   database: 5,
+                   name: FunWithFlags.Store.Persistent.Redis,
+                   sync_connect: false
+                 ]
+               ]},
+              type: :worker
+            }
+          ]
+        }
+      }
+
+      assert ^expected = FunWithFlags.Supervisor.init(nil)
+    end
+
+    @tag :ecto_persistence
+    @tag :phoenix_pubsub
+    test "with Ecto persistence and Phoenix PubSub, no cache" do
+      expected = {
+        :ok,
+        {
+          %{intensity: 3, period: 5, strategy: :one_for_one},
+          []
+        }
+      }
+
+      assert ^expected = FunWithFlags.Supervisor.init(nil)
+    end
+  end
+end


### PR DESCRIPTION
Addresses https://github.com/tompave/fun_with_flags/issues/31

This PR introduces extracts from the application module all the supervision logic into new `FunWithFlags.Supervisor` module. This new module can be used directly if users of the package want to manage the supervision tree directly. The PR also adds detailed instructions on how to accomplish this.

To inspect the new docs: https://github.com/tompave/fun_with_flags/tree/custom_start#application-start-behaviour