### PR TITLE
Fix runtime persistence config for releases, resolves #109

### DIFF
--- a/lib/fun_with_flags/simple_store.ex
+++ b/lib/fun_with_flags/simple_store.ex
@@ -10,10 +10,23 @@ defmodule FunWithFlags.SimpleStore do
     end
   end
 
-  defdelegate put(flag_name, gate), to: persistence_adapter()
-  defdelegate delete(flag_name, gate), to: persistence_adapter()
-  defdelegate delete(flag_name), to: persistence_adapter()
-  defdelegate all_flags(), to: persistence_adapter()
-  defdelegate all_flag_names(), to: persistence_adapter()
+  def put(flag_name, gate) do
+    persistence_adapter().put(flag_name, gate)
+  end
 
+  def delete(flag_name, gate) do
+    persistence_adapter().delete(flag_name, gate)
+  end
+
+  def delete(flag_name) do
+    persistence_adapter().delete(flag_name)
+  end
+
+  def all_flags do
+    persistence_adapter().all_flags()
+  end
+
+  def all_flag_names do
+    persistence_adapter().all_flag_names()
+  end
 end

--- a/lib/fun_with_flags/store.ex
+++ b/lib/fun_with_flags/store.ex
@@ -63,10 +63,13 @@ defmodule FunWithFlags.Store do
     |> cache_persistence_result()
   end
 
+  def all_flags do
+    persistence_adapter().all_flags()
+  end
 
-  defdelegate all_flags(), to: persistence_adapter()
-  defdelegate all_flag_names(), to: persistence_adapter()
-
+  def all_flag_names do
+    persistence_adapter().all_flag_names()
+  end
 
   defp cache_persistence_result(result) do
     case result do


### PR DESCRIPTION
`defdelegate/2` calls `persistence_adapter/0` at compile-time, causing system env configuration to be read prematurely and stored into the function definition itself. This commit replaces calls to `defdelegate/2` with functions that call `persistence_adapter/0` at runtime, fixing the issue.

I believe this resolves #109.