### PR TITLE
 Allow Ecto.UUID PKs

### DIFF
--- a/lib/fun_with_flags/config.ex
+++ b/lib/fun_with_flags/config.ex
@@ -19,7 +19,8 @@ defmodule FunWithFlags.Config do
   @default_persistence_config [
     adapter: FunWithFlags.Store.Persistent.Redis,
     repo: FunWithFlags.NullEctoRepo,
-    ecto_table_name: "fun_with_flags_toggles"
+    ecto_table_name: "fun_with_flags_toggles",
+    ecto_primary_key_type: :id
   ]
 
   def redis_config do
@@ -35,6 +36,11 @@ defmodule FunWithFlags.Config do
 
   def ecto_table_name do
     Keyword.get(persistence_config(), :ecto_table_name)
+  end
+
+
+  def ecto_primary_key_type do
+    Keyword.get(persistence_config(), :ecto_primary_key_type)
   end
 
 

--- a/lib/fun_with_flags/store/persistent/ecto/record.ex
+++ b/lib/fun_with_flags/store/persistent/ecto/record.ex
@@ -6,7 +6,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto.Record do
   import Ecto.Changeset
   alias FunWithFlags.{Config, Gate}
 
-  @primary_key {:id, :id, autogenerate: true}
+  @primary_key {:id, Config.ecto_primary_key_type(), autogenerate: true}
 
   schema Config.ecto_table_name() do
     field :flag_name, :string


### PR DESCRIPTION
Adds a compile-time config of `:ecto_primary_key_type` allowing use optional use of `Ecto.UUID` 