### PR TITLE
More precise Ecto compilation guards.

### DIFF
--- a/lib/fun_with_flags/store/persistent/ecto.ex
+++ b/lib/fun_with_flags/store/persistent/ecto.ex
@@ -1,4 +1,4 @@
-if Code.ensure_loaded?(Ecto) do
+if Code.ensure_loaded?(Ecto.Adapters.SQL) do
 
 defmodule FunWithFlags.Store.Persistent.Ecto do
   @moduledoc false

--- a/lib/fun_with_flags/store/persistent/ecto/record.ex
+++ b/lib/fun_with_flags/store/persistent/ecto/record.ex
@@ -1,4 +1,4 @@
-if Code.ensure_loaded?(Ecto) do
+if Code.ensure_loaded?(Ecto.Adapters.SQL) do
 
 defmodule FunWithFlags.Store.Persistent.Ecto.Record do
   @moduledoc false

--- a/lib/fun_with_flags/store/serializer/ecto.ex
+++ b/lib/fun_with_flags/store/serializer/ecto.ex
@@ -1,4 +1,4 @@
-if Code.ensure_loaded?(Ecto) do
+if Code.ensure_loaded?(Ecto.Adapters.SQL) do
 
 defmodule FunWithFlags.Store.Serializer.Ecto do
   @moduledoc false


### PR DESCRIPTION
Check for `ecto_sql` instead of just `ecto` in the conditional compilation guards.

It might solve https://github.com/tompave/fun_with_flags/issues/137.