### PR TITLE
Add a custom query option to Ecto queries, closes #94

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ config :fun_with_flags, :persistence,
 
 It's also necessary to create the DB table that will hold the feature flag data. To do that, [create a new migration](https://hexdocs.pm/ecto_sql/Mix.Tasks.Ecto.Gen.Migration.html) in your project and copy the contents of [the provided migration file](https://github.com/tompave/fun_with_flags/blob/master/priv/ecto_repo/migrations/00000000000000_create_feature_flags_table.exs). Then [run the migration](https://hexdocs.pm/ecto_sql/Mix.Tasks.Ecto.Migrate.html).
 
-If you followed the Ecto guide on setting up [multi-tenancy with foreign keys](https://hexdocs.pm/ecto/multi-tenancy-with-foreign-keys.html), you must add an exemption for queries originating from FunWithFlags. These queries have a custom query option named `:fun_with_flags` set to `true`:
+If you followed the Ecto guide on setting up [multi-tenancy with foreign keys](https://hexdocs.pm/ecto/multi-tenancy-with-foreign-keys.html), you must add an exception for queries originating from FunWithFlags. These queries have a custom query option named `:fun_with_flags` set to `true`:
 
 ```elixir
 # Sample code, only relevant if you followed the Ecto guide on multi tenancy with foreign keys

--- a/README.md
+++ b/README.md
@@ -597,6 +597,32 @@ config :fun_with_flags, :persistence,
 
 It's also necessary to create the DB table that will hold the feature flag data. To do that, [create a new migration](https://hexdocs.pm/ecto_sql/Mix.Tasks.Ecto.Gen.Migration.html) in your project and copy the contents of [the provided migration file](https://github.com/tompave/fun_with_flags/blob/master/priv/ecto_repo/migrations/00000000000000_create_feature_flags_table.exs). Then [run the migration](https://hexdocs.pm/ecto_sql/Mix.Tasks.Ecto.Migrate.html).
 
+If you followed the Ecto guide on setting up [multi-tenancy with foreign keys](https://hexdocs.pm/ecto/multi-tenancy-with-foreign-keys.html), you must add an exemption for queries originating from FunWithFlags. These queries have a custom query option named `:fun_with_flags` set to `true`:
+
+```elixir
+# Sample code, only relevant if you followed the Ecto guide on multi tenancy with foreign keys
+defmodule MyApp.Repo do
+  use Ecto.Repo, otp_app: :my_app
+
+  require Ecto.Query
+
+  @impl true
+  def prepare_query(_operation, query, opts) do
+    cond do
+      # add the check for opts[:fun_with_flags] here:
+      opts[:skip_org_id] || opts[:schema_migration] || opts[:fun_with_flags] ->
+        {query, opts}
+
+      org_id = opts[:org_id] ->
+        {Ecto.Query.where(query, org_id: ^org_id), opts}
+
+      true ->
+        raise "expected org_id or skip_org_id to be set"
+    end
+  end
+end
+```
+
 ### PubSub Adapters
 
 The library comes with two PubSub adapters for the [`Redix`](https://hex.pm/packages/redix) and [`Phoenix.PubSub`](https://hex.pm/packages/phoenix_pubsub) libraries. In order to use any of them, you must declare the correct optional dependency in the Mixfile. (see the [installation](#installation) instructions, below)

--- a/dev_support/ecto/repo.ex
+++ b/dev_support/ecto/repo.ex
@@ -12,5 +12,23 @@ if FunWithFlags.Config.persist_in_ecto? do
     end)
 
     use Ecto.Repo, otp_app: :fun_with_flags, adapter: @variant
+    
+    # for testing setups that use multi-tenancy using foreign keys
+    # as described in the Ecto docs:
+    # https://hexdocs.pm/ecto/multi-tenancy-with-foreign-keys.html
+    #
+    # FunWithFlags sets the custom query option `:fun_with_flags` to
+    # true to allow such setups to detect queries originating from
+    # FunWithFlags
+    @impl true
+    def prepare_query(_operation, query, opts) do
+      cond do
+        opts[:schema_migration] || opts[:fun_with_flags] ->
+          {query, opts}
+
+        true ->
+          raise "expected fun_with_flags query option to be set"
+      end
+    end
   end
 end

--- a/lib/fun_with_flags/store/persistent/ecto.ex
+++ b/lib/fun_with_flags/store/persistent/ecto.ex
@@ -15,6 +15,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
   require Logger
 
   @mysql_lock_timeout_s 3
+  @query_opts [fun_with_flags: true]
 
 
   @impl true
@@ -28,7 +29,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
     name_string = to_string(flag_name)
     query = from(r in Record, where: r.flag_name == ^name_string)
     try do
-      results = ecto_repo().all(query)
+      results = ecto_repo().all(query, @query_opts)
       flag = deserialize(flag_name, results)
       {:ok, flag}
     rescue
@@ -56,7 +57,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
     end
 
     out = transaction_fn.(repo, fn() ->
-      case repo.one(find_one_q) do
+      case repo.one(find_one_q, @query_opts) do
         record = %Record{} ->
           changeset = Record.update_target(record, gate)
           do_update(repo, flag_name, changeset)
@@ -146,7 +147,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
     )
 
     try do
-      {_count, _} = ecto_repo().delete_all(query)
+      {_count, _} = ecto_repo().delete_all(query, @query_opts)
       {:ok, flag} = get(flag_name)
       {:ok, flag}
     rescue
@@ -173,7 +174,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
     )
 
     try do
-      {_count, _} = ecto_repo().delete_all(query)
+      {_count, _} = ecto_repo().delete_all(query, @query_opts)
       {:ok, flag} = get(flag_name)
       {:ok, flag}
     rescue
@@ -198,7 +199,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
     )
 
     try do
-      {_count, _} = ecto_repo().delete_all(query)
+      {_count, _} = ecto_repo().delete_all(query, @query_opts)
       {:ok, flag} = get(flag_name)
       {:ok, flag}
     rescue
@@ -211,7 +212,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
   def all_flags do
     flags =
       Record
-      |> ecto_repo().all()
+      |> ecto_repo().all(@query_opts)
       |> Enum.group_by(&(&1.flag_name))
       |> Enum.map(fn ({name, records}) -> deserialize(name, records) end)
     {:ok, flags}
@@ -223,7 +224,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
   @impl true
   def all_flag_names do
     query = from(r in Record, select: r.flag_name, distinct: true)
-    strings = ecto_repo().all(query)
+    strings = ecto_repo().all(query, @query_opts)
     atoms = Enum.map(strings, &String.to_atom(&1))
     {:ok, atoms}
   rescue


### PR DESCRIPTION
When having a setup similar to what's described in the official Ecto guides on setting up multi tenancy with foreign keys, the queries originating from FunWithFlags can fail, as the tenant key is not set. See https://hexdocs.pm/ecto/multi-tenancy-with-foreign-keys.html.

This PR adds a custom query option (`:fun_with_flags`) to allow an easy detection of these queries and to skip the tenant key check. The test repo was changed to check for this option and raise if it is not set.

Closes #94.