### PR TITLE
Add support for Redis config in the tuple form

### DIFF
--- a/lib/fun_with_flags/config.ex
+++ b/lib/fun_with_flags/config.ex
@@ -28,6 +28,8 @@ defmodule FunWithFlags.Config do
     case Application.get_env(:fun_with_flags, :redis, []) do
       uri  when is_binary(uri) ->
         uri
+      {uri, opts} when is_binary(uri) and is_list(opts) ->
+        {uri, opts}
       opts when is_list(opts) ->
         if Keyword.has_key?(opts, :sentinel) do
           @default_redis_config

--- a/lib/fun_with_flags/store/persistent/redis.ex
+++ b/lib/fun_with_flags/store/persistent/redis.ex
@@ -19,6 +19,8 @@ defmodule FunWithFlags.Store.Persistent.Redis do
     conf = case Config.redis_config do
       uri when is_binary(uri) ->
         {uri, @conn_options}
+      {uri, opts} when is_binary(uri) and is_list(opts) ->
+        {uri, Keyword.merge(opts, @conn_options)}
       opts when is_list(opts) ->
         Keyword.merge(opts, @conn_options)
     end

--- a/test/fun_with_flags/config_test.exs
+++ b/test/fun_with_flags/config_test.exs
@@ -22,6 +22,12 @@ defmodule FunWithFlags.ConfigTest do
     configure_redis_with(url)
     assert ^url = Config.redis_config
 
+    # when configured to use a URL + Redis config tuple, it returns the tuple and ignores the defaults
+    url = "redis:://localhost:1234/1"
+    configure_redis_with({url, socket_opts: [:inet6]})
+    {^url, opts} = Config.redis_config
+    assert [socket_opts: [:inet6]] == opts
+
     # when configured to use sentinel, it returns sentinel without default host and port
     sentinel = [sentinel: [sentinels: ["redis:://locahost:1234/1"], group: "primary"], database: 5]
     configure_redis_with(sentinel)


### PR DESCRIPTION
# Problem
We have an app that's deployed on Fly.io. In order to connect to a Redis database provided by upstash.com, we must include the `socket_opts: [:inet6]` option in our Redis config. Unfortunately, the two configuration formats supported by this library do not enable us to easily configure app in this way.

1. The URI-only form, e.g. `config :fun_with_flags, :redis, {:system, "REDIS_URI"}` does not give us the ability to specify the socket options
2. The opt-list form, e.g. `config :fun_with_flags, :redis, host: ..., username: ..., password: ..., socket_opts: [:inet6]` requires us to parse our Redis URI and then the user/pass part in order to configure the Redis connection

# Solution
Add support for the Redix configuration in the form of `{url, connection_options}` so that we can configure apps directly within the constraints of its environment.

# Note
I noticed that the URI-only form appears to exercise an [untested code path](https://github.com/tompave/fun_with_flags/blob/ec1340b79a9349b91afa11894a2547ff708cf2d2/lib/fun_with_flags/store/persistent/redis.ex#L21). Assuming I am seeing that correctly, I opted to add my own new codepath without a test. I realize that this is somewhat risky, so please advise if there is a way to ensure the new code path is tested.