### PR TITLE
Add another case for Redis initialization

### DIFF
--- a/lib/fun_with_flags/notifications/redis.ex
+++ b/lib/fun_with_flags/notifications/redis.ex
@@ -21,8 +21,6 @@ defmodule FunWithFlags.Notifications.Redis do
     redis_conn_config = case Config.redis_config do
       uri when is_binary(uri) ->
         {uri, @conn_options}
-      {uri, opts} when is_binary(uri) and is_list(opts) ->
-        Redix.PubSub.start_link(uri, Keyword.merge(opts, @conn_options))
       opts when is_list(opts) ->
         Keyword.merge(opts, @conn_options)
     end

--- a/lib/fun_with_flags/notifications/redis.ex
+++ b/lib/fun_with_flags/notifications/redis.ex
@@ -21,6 +21,8 @@ defmodule FunWithFlags.Notifications.Redis do
     redis_conn_config = case Config.redis_config do
       uri when is_binary(uri) ->
         {uri, @conn_options}
+      {uri, opts} when is_binary(uri) and is_list(opts) ->
+        Redix.PubSub.start_link(uri, Keyword.merge(opts, @conn_options))
       opts when is_list(opts) ->
         Keyword.merge(opts, @conn_options)
     end

--- a/lib/fun_with_flags/notifications/redis.ex
+++ b/lib/fun_with_flags/notifications/redis.ex
@@ -21,6 +21,8 @@ defmodule FunWithFlags.Notifications.Redis do
     redis_conn_config = case Config.redis_config do
       uri when is_binary(uri) ->
         {uri, @conn_options}
+      {uri, opts} when is_binary(uri) and is_list(opts) ->
+        {uri, Keyword.merge(opts, @conn_options)}
       opts when is_list(opts) ->
         Keyword.merge(opts, @conn_options)
     end

--- a/test/fun_with_flags/notifications/redis_test.exs
+++ b/test/fun_with_flags/notifications/redis_test.exs
@@ -91,7 +91,7 @@ defmodule FunWithFlags.Notifications.RedisTest do
       assert {:ok, _pid} = NotifiRedis.publish_change(name)
 
       payload = "#{u_id}:#{to_string(name)}"
-      
+
       receive do
         {:redix_pubsub, ^receiver, ^ref, :message, %{channel: ^channel, payload: ^payload}} -> :ok
       after
@@ -150,7 +150,7 @@ defmodule FunWithFlags.Notifications.RedisTest do
 
     test "when the message is not valid, it is ignored" do
       channel = "fun_with_flags_changes"
-      
+
       with_mock(Store, [:passthrough], []) do
         Redix.command(PersiRedis, ["PUBLISH", channel, "foobar"])
         :timer.sleep(30)
@@ -163,7 +163,7 @@ defmodule FunWithFlags.Notifications.RedisTest do
       u_id = NotifiRedis.unique_id()
       channel = "fun_with_flags_changes"
       message = "#{u_id}:foobar"
-      
+
       with_mock(Store, [:passthrough], []) do
         Redix.command(PersiRedis, ["PUBLISH", channel, message])
         :timer.sleep(30)
@@ -178,7 +178,7 @@ defmodule FunWithFlags.Notifications.RedisTest do
 
       channel = "fun_with_flags_changes"
       message = "#{another_u_id}:foobar"
-      
+
       with_mock(Store, [:passthrough], []) do
         Redix.command(PersiRedis, ["PUBLISH", channel, message])
         :timer.sleep(30)
@@ -216,7 +216,7 @@ defmodule FunWithFlags.Notifications.RedisTest do
 
     test "when the message is not valid, the Cached value is not changed", %{name: name, cached_flag: cached_flag} do
       channel = "fun_with_flags_changes"
-      
+
       Redix.command(PersiRedis, ["PUBLISH", channel, to_string(name)])
       :timer.sleep(30)
       assert {:ok, ^cached_flag} = Cache.get(name)
@@ -227,7 +227,7 @@ defmodule FunWithFlags.Notifications.RedisTest do
       u_id = NotifiRedis.unique_id()
       channel = "fun_with_flags_changes"
       message = "#{u_id}:#{to_string(name)}"
-      
+
       Redix.command(PersiRedis, ["PUBLISH", channel, message])
       :timer.sleep(30)
       assert {:ok, ^cached_flag} = Cache.get(name)
@@ -240,7 +240,7 @@ defmodule FunWithFlags.Notifications.RedisTest do
 
       channel = "fun_with_flags_changes"
       message = "#{another_u_id}:#{to_string(name)}"
-      
+
       assert {:ok, ^cached_flag} = Cache.get(name)
       Redix.command(PersiRedis, ["PUBLISH", channel, message])
       :timer.sleep(30)

--- a/test/fun_with_flags/notifications/redis_test.exs
+++ b/test/fun_with_flags/notifications/redis_test.exs
@@ -37,7 +37,6 @@ defmodule FunWithFlags.Notifications.RedisTest do
       assert ^expected = NotifiRedis.worker_spec()
     end
 
-    @tag :skip
     test "when the Redis config is a {URL, opts} tuple" do
       url = "redis:://1.2.3.4:5678/42"
       opts = [socket_opts: [:inet6]]
@@ -49,12 +48,14 @@ defmodule FunWithFlags.Notifications.RedisTest do
           FunWithFlags.Notifications.Redis,
           :start_link,
           [
-            url,
-            [
-              socket_opts: [:inet6],
-              name: FunWithFlags.Store.Notifications.Redis,
-              sync_connect: false
-            ]
+            {
+              url,
+              [
+                socket_opts: [:inet6],
+                name: :fun_with_flags_notifications,
+                sync_connect: false
+              ]
+            }
           ]
         },
         type: :worker,


### PR DESCRIPTION
# Problem
An initialization case for Redix was missed in #145. This is unfortunate and probably justifies figuring out how to get a set of tests around the different configuration forms.

This was discovered by using v1.10.0 in a production app and receiving the error:

```
** (Mix) Could not start application fun_with_flags: FunWithFlags.Application.start(:normal, []) returned an error: shutdown: failed to start child: FunWithFlags.Notifications.Redis
    ** (EXIT) an exception was raised:
        ** (CaseClauseError) no case clause matching: {"redis://localhost", [socket_opts: [:inet6]]}
            (fun_with_flags 1.10.0) lib/fun_with_flags/notifications/redis.ex:73: FunWithFlags.Notifications.Redis.init/1
            (stdlib 4.1) gen_server.erl:851: :gen_server.init_it/2
            (stdlib 4.1) gen_server.erl:814: :gen_server.init_it/6
            (stdlib 4.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
```

# Solution
- Add new case
- Add tests (???)