### PR TITLE
Redis notifications: refactor handling of connection settings.

### DIFF
--- a/lib/fun_with_flags/store/persistent/redis.ex
+++ b/lib/fun_with_flags/store/persistent/redis.ex
@@ -14,6 +14,9 @@ defmodule FunWithFlags.Store.Persistent.Redis do
   @flags_set "fun_with_flags"
 
 
+  # Retrieve the configuration to connect to Redis, and package it as an argument
+  # to be passed to the start_link function.
+  #
   @impl true
   def worker_spec do
     conf = case Config.redis_config do

--- a/test/fun_with_flags/supervisor_test.exs
+++ b/test/fun_with_flags/supervisor_test.exs
@@ -45,7 +45,9 @@ defmodule FunWithFlags.SupervisorTest do
             %{
               id: FunWithFlags.Notifications.Redis,
               restart: :permanent,
-              start: {FunWithFlags.Notifications.Redis, :start_link, []},
+              start: {FunWithFlags.Notifications.Redis, :start_link, [
+                [host: "localhost", port: 6379, database: 5, name: :fun_with_flags_notifications, sync_connect: false]
+              ]},
               type: :worker
             }
           ]


### PR DESCRIPTION
Move handling of the `Notifications.Redis` connection config to the `worker_spec`.

This makes it more consistent with how the `Persistent.Redis` adapter behaves.