### PR TITLE
no longer start an application 

### DIFF
--- a/lib/fun_with_flags/application.ex
+++ b/lib/fun_with_flags/application.ex
@@ -1,9 +1,0 @@
-defmodule FunWithFlags.Application do
-  @moduledoc false
-
-  use Application
-
-  def start(_type, _args) do
-    FunWithFlags.Supervisor.start_link(nil)
-  end
-end

--- a/mix.exs
+++ b/mix.exs
@@ -23,8 +23,7 @@ defmodule FunWithFlags.Mixfile do
 
   def application do
     # Specify extra applications you'll use from Erlang/Elixir
-    [extra_applications: extra_applications(Mix.env),
-     mod: {FunWithFlags.Application, []}]
+    [extra_applications: extra_applications(Mix.env())]
   end
 
   defp extra_applications(:test), do: local_extra_applications()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -41,6 +41,8 @@ if does_anything_need_redis do
   FunWithFlags.TestUtils.use_redis_test_db()
 end
 
+FunWithFlags.Supervisor.start_link(nil)
+
 ExUnit.start()
 
 if FunWithFlags.Config.persist_in_ecto? do


### PR DESCRIPTION
This PR removes the `application.ex` and also removes the mod key from the application config, so nothing is started automatically.

the fun with flags supervisor MUST be included in the consuming application.

Can include documentation updates if this will be considered for 2.0 to ensure it does not break existing deployments 

Relevant discussion: https://github.com/elixir-lang/elixir/issues/9683