### PR TITLE
Add timestamps to Ecto DB table

### DIFF
--- a/lib/fun_with_flags/store/persistent/ecto/record.ex
+++ b/lib/fun_with_flags/store/persistent/ecto/record.ex
@@ -13,6 +13,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto.Record do
     field :gate_type, :string
     field :target, :string
     field :enabled, :boolean
+    timestamps()
   end
 
   @fields [:flag_name, :gate_type, :target, :enabled]

--- a/priv/ecto_repo/migrations/00000000000000_create_feature_flags_table.exs
+++ b/priv/ecto_repo/migrations/00000000000000_create_feature_flags_table.exs
@@ -12,6 +12,7 @@ defmodule FunWithFlags.Dev.EctoRepo.Migrations.CreateFeatureFlagsTable do
       add :gate_type, :string, null: false
       add :target, :string, null: false
       add :enabled, :boolean, null: false
+      timestamps()
     end
 
     create index(

--- a/priv/ecto_repo/migrations/00000000000002_add_timestamps.exs
+++ b/priv/ecto_repo/migrations/00000000000002_add_timestamps.exs
@@ -1,0 +1,32 @@
+defmodule FunWithFlags.Dev.EctoRepo.Migrations.EnsureColumnsAreNotNull do
+  use Ecto.Migration
+  #
+  # Use this migration to add the ecto `inserted_at` and `updated_at` columns
+  # to the table created using the `CreateFeatureFlagsTable` migration
+  # from versions `<= 1.10.0`.
+  #
+  # https://hexdocs.pm/ecto_sql/Ecto.Migration.html#timestamps/1
+  #
+  # If the table has been created with a migration from `>= 1.11.0`,
+  # then the `timestamp` columns are already there and there
+  # is no need to run this migration. In that case, this migration
+  # is a no-op.
+  #
+  # This migration assumes the default table name of "fun_with_flags_toggles"
+  # is being used. If you have overridden that via configuration, you should
+  # change this migration accordingly.
+
+  def up do
+    case repo.query("select inserted_at, updated_at from fun_with_flags_toggles where false") do
+      {:ok, %{num_rows: 0}} ->
+        # timestamp columns exist, do nothing
+        true
+
+      {:error, _} ->
+        # Assume error is from timestamp columns not existing, run migration
+        alter table(:fun_with_flags_toggles) do
+          timestamps()
+        end
+    end
+  end
+end


### PR DESCRIPTION
This adds `inserted_at` and `updated_at` columns to the database table when using Ecto, and uses the built-in Ecto behavior to populate their values without any additional work. This makes it possible to directly measure how long a given flag has been in its current state, which in turn makes it easier to determine when a flag is safe to be removed (i.e. that it has been "on" for some/many/all users for "long enough" that we haven't observed any downsides).