### PR TITLE
Add support for :binary_id Ecto primary key type

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,8 +595,9 @@ config :my_app, MyApp.Repo,
 config :fun_with_flags, :persistence,
   adapter: FunWithFlags.Store.Persistent.Ecto,
   repo: MyApp.Repo,
-  ecto_table_name: "your_table_name" # optional
-  # Default table name is "fun_with_flags_toggles".
+  ecto_table_name: "your_table_name", # optional, defaults to "fun_with_flags_toggles"
+  ecto_primary_key_type: :binary_id # optional, defaults to :id
+  # For the primary key type, see also: https://hexdocs.pm/ecto/3.10.3/Ecto.Schema.html#module-schema-attributes
 ```
 
 It's also necessary to create the DB table that will hold the feature flag data. To do that, [create a new migration](https://hexdocs.pm/ecto_sql/Mix.Tasks.Ecto.Gen.Migration.html) in your project and copy the contents of [the provided migration file](https://github.com/tompave/fun_with_flags/blob/master/priv/ecto_repo/migrations/00000000000000_create_feature_flags_table.exs). Then [run the migration](https://hexdocs.pm/ecto_sql/Mix.Tasks.Ecto.Migrate.html).
@@ -670,6 +671,13 @@ config :fun_with_flags, :cache_bust_notifications,
   adapter: FunWithFlags.Notifications.PhoenixPubSub,
   client: :my_pubsub_process_name
 ```
+
+#### Ecto Custom Primary Key Types
+
+The library defaults to using an integer (`bigserial`) as the type of the `id` primary key column. If, for any reason, you need the ID to be a UUID, you can configure it to be of type `:binary_id`. To do that, you need to:
+
+  1. Set the `:ecto_primary_key_type` configuration option to `:binary_id`.
+  2. Use `:binary_id` as the type of the `:id` column in the [provided migration file](https://github.com/tompave/fun_with_flags/blob/master/priv/ecto_repo/migrations/00000000000000_create_feature_flags_table.exs).
 
 ## Extensibility
 

--- a/lib/fun_with_flags/config.ex
+++ b/lib/fun_with_flags/config.ex
@@ -21,7 +21,8 @@ defmodule FunWithFlags.Config do
   @default_persistence_config [
     adapter: FunWithFlags.Store.Persistent.Redis,
     repo: FunWithFlags.NullEctoRepo,
-    ecto_table_name: "fun_with_flags_toggles"
+    ecto_table_name: "fun_with_flags_toggles",
+    ecto_primary_key_type: :id
   ]
 
   def redis_config do
@@ -93,6 +94,15 @@ defmodule FunWithFlags.Config do
       @compile_time_persistence_config
     )
     Keyword.get(pers_conf, :ecto_table_name)
+  end
+
+
+  def ecto_primary_key_type_determined_at_compile_time do
+    pers_conf = Keyword.merge(
+      @default_persistence_config,
+      @compile_time_persistence_config
+    )
+    Keyword.get(pers_conf, :ecto_primary_key_type)
   end
 
 

--- a/lib/fun_with_flags/store/persistent/ecto/record.ex
+++ b/lib/fun_with_flags/store/persistent/ecto/record.ex
@@ -6,7 +6,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto.Record do
   import Ecto.Changeset
   alias FunWithFlags.{Config, Gate}
 
-  @primary_key {:id, :id, autogenerate: true}
+  @primary_key {:id, Config.ecto_primary_key_type_determined_at_compile_time(), autogenerate: true}
 
   schema Config.ecto_table_name_determined_at_compile_time() do
     field :flag_name, :string

--- a/priv/ecto_repo/migrations/00000000000000_create_feature_flags_table.exs
+++ b/priv/ecto_repo/migrations/00000000000000_create_feature_flags_table.exs
@@ -8,6 +8,9 @@ defmodule FunWithFlags.Dev.EctoRepo.Migrations.CreateFeatureFlagsTable do
   def up do
     create table(:fun_with_flags_toggles, primary_key: false) do
       add :id, :bigserial, primary_key: true
+      # If you configure :ecto_primary_key_type to be :binary_id, you should replace
+      # the line above with:
+      # add :id, :binary_id, primary_key: true
       add :flag_name, :string, null: false
       add :gate_type, :string, null: false
       add :target, :string, null: false

--- a/test/fun_with_flags/config_test.exs
+++ b/test/fun_with_flags/config_test.exs
@@ -139,6 +139,12 @@ defmodule FunWithFlags.ConfigTest do
     end
   end
 
+  describe "ecto_primary_key_type_determined_at_compile_time()" do
+    test "it defaults to :id" do
+      assert Config.ecto_primary_key_type_determined_at_compile_time() == :id
+    end
+  end
+
   describe "When we are sending notifications with Redis PubSub" do
     @describetag :redis_pubsub
 


### PR DESCRIPTION
My awesome coworker @vinniefranco made these changes a while ago: https://github.com/vinniefranco/fun_with_flags/commit/b432c4e1a108d6207be58106c7fcf446214736e3

I updated the README and thought maybe this could make it upstream, and eventually be released 🙃 We've been using this code in production for a good while now. The value could also be `Ecto.UUID`, for example.