### PR TITLE
Fix disable/2 typespec

### DIFF
--- a/lib/fun_with_flags.ex
+++ b/lib/fun_with_flags.ex
@@ -306,7 +306,7 @@ defmodule FunWithFlags do
       {:ok, false}
 
   """
-  @spec disable(atom, options) :: {:ok, false} | {:error, any}
+  @spec disable(atom, options) :: {:ok, boolean()} | {:error, any}
   def disable(flag_name, options \\ [])
 
   def disable(flag_name, []) when is_atom(flag_name) do


### PR DESCRIPTION
Fix #169 

Considering that `disable` calls the internal `verify` function that may return `true`, I guess typespec just needs to be updated.

Let me know if this is incorrect.