### PR TITLE
Optimize checking gates

### DIFF
--- a/lib/fun_with_flags/flag.ex
+++ b/lib/fun_with_flags/flag.ex
@@ -59,23 +59,26 @@ defmodule FunWithFlags.Flag do
 
   defp check_actor_gates(gates, item) do
     gates
-    |> actor_gates()
     |> do_check_actor_gates(item)
   end
 
+
   defp do_check_actor_gates([], _), do: :ignore
 
-  defp do_check_actor_gates([gate|rest], item) do
+  defp do_check_actor_gates([%Gate{type: :actor} = gate | rest], item) do
     case Gate.enabled?(gate, for: item) do
       :ignore -> do_check_actor_gates(rest, item)
       result  -> result
     end
   end
 
+  defp do_check_actor_gates([_gate | rest], item) do
+    do_check_actor_gates(rest, item)
+  end
+
 
   defp check_group_gates(gates, item) do
     gates
-    |> group_gates()
     |> do_check_group_gates(item)
   end
 
@@ -92,12 +95,16 @@ defmodule FunWithFlags.Flag do
 
   defp do_check_group_gates([], _, result), do: result
 
-  defp do_check_group_gates([gate|rest], item, temp_result) do
+  defp do_check_group_gates([%Gate{type: :group} = gate|rest], item, temp_result) do
     case Gate.enabled?(gate, for: item) do
       :ignore      -> do_check_group_gates(rest, item, temp_result)
       {:ok, false} -> {:ok, false}
       {:ok, true}  -> do_check_group_gates(rest, item, {:ok, true})
     end
+  end
+
+  defp do_check_group_gates([_gate | rest], item, temp_result) do
+    do_check_group_gates(rest, item, temp_result)
   end
 
 
@@ -131,14 +138,6 @@ defmodule FunWithFlags.Flag do
 
   defp boolean_gate(gates) do
     Enum.find(gates, &Gate.boolean?/1)
-  end
-
-  defp actor_gates(gates) do
-    Enum.filter(gates, &Gate.actor?/1)
-  end
-
-  defp group_gates(gates) do
-    Enum.filter(gates, &Gate.group?/1)
   end
 
   defp percentage_of_time_gate(gates) do


### PR DESCRIPTION
We use actor-based gates pretty extensively during new feature rollup process and noticed significant slowdowns when flag contains large number of gates (>20k) and is checked multiple times.

Current approach relies on intermediary list created by `Enum.filter/2`. With new approach only reduce is used.

Benchmark below (5k gates):
```
--------------------------------------------------------------
$CACHE_ENABLED=true
$PERSISTENCE=ecto
$RDBMS=postgres
$PUBSUB_BROKER=phoenix_pubsub
$CI=
--------------------------------------------------------------
Elixir version:        1.16.2
Erlang/OTP version:    Erlang/OTP 26 [erts-14.0] [source] [64-bit] [smp:10:10] [ds:10:10:10] [async-threads:1] [jit]
Logger level:          :error
Cache enabled:         true
Persistence adapter:   FunWithFlags.Store.Persistent.Ecto
RDBMS driver:          Ecto.Adapters.Postgres
Notifications adapter: FunWithFlags.Notifications.PhoenixPubSub
Anything using Redis:  false
--------------------------------------------------------------
Excluding tags: [:redis_pubsub, :redis_persistence]

...............................................................................................................................................Operating System: macOS
CPU Information: Apple M1 Max
Number of Available Cores: 10
Available memory: 64 GB
Elixir 1.16.2
Erlang 26.0
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 2 s
reduction time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 18 s

Benchmarking new ...
Benchmarking old ...
Calculating statistics...
Formatting results...

Name                 ips        average  deviation         median         99th %
new        1.49 K      669.04 μs     ±1.22%      667.92 μs      692.98 μs
old        1.29 K      775.76 μs    ±12.13%      736.63 μs     1028.36 μs

Comparison:
new        1.49 K
old        1.29 K - 1.16x slower +106.73 μs

Memory usage statistics:

Name          Memory usage
new       468.84 KB
old       546.98 KB - 1.17x memory usage +78.14 KB

**All measurements for memory usage were the same**
```