### PR TITLE
Tidy up the functions in the Flag module

### DIFF
--- a/lib/fun_with_flags/flag.ex
+++ b/lib/fun_with_flags/flag.ex
@@ -57,29 +57,17 @@ defmodule FunWithFlags.Flag do
   end
 
 
-  defp check_actor_gates(gates, item) do
-    gates
-    |> do_check_actor_gates(item)
-  end
+  defp check_actor_gates([], _), do: :ignore
 
-
-  defp do_check_actor_gates([], _), do: :ignore
-
-  defp do_check_actor_gates([%Gate{type: :actor} = gate | rest], item) do
+  defp check_actor_gates([%Gate{type: :actor} = gate | rest], item) do
     case Gate.enabled?(gate, for: item) do
-      :ignore -> do_check_actor_gates(rest, item)
+      :ignore -> check_actor_gates(rest, item)
       result  -> result
     end
   end
 
-  defp do_check_actor_gates([_gate | rest], item) do
-    do_check_actor_gates(rest, item)
-  end
-
-
-  defp check_group_gates(gates, item) do
-    gates
-    |> do_check_group_gates(item)
+  defp check_actor_gates([_gate | rest], item) do
+    check_actor_gates(rest, item)
   end
 
 
@@ -91,20 +79,20 @@ defmodule FunWithFlags.Flag do
   # If a group gate is enabled, store the result but keep
   # looping in case there is another group that is disabled.
   #
-  defp do_check_group_gates(gates, item, result \\ :ignore)
+  defp check_group_gates(gates, item, result \\ :ignore)
 
-  defp do_check_group_gates([], _, result), do: result
+  defp check_group_gates([], _, result), do: result
 
-  defp do_check_group_gates([%Gate{type: :group} = gate|rest], item, temp_result) do
+  defp check_group_gates([%Gate{type: :group} = gate|rest], item, temp_result) do
     case Gate.enabled?(gate, for: item) do
-      :ignore      -> do_check_group_gates(rest, item, temp_result)
+      :ignore      -> check_group_gates(rest, item, temp_result)
       {:ok, false} -> {:ok, false}
-      {:ok, true}  -> do_check_group_gates(rest, item, {:ok, true})
+      {:ok, true}  -> check_group_gates(rest, item, {:ok, true})
     end
   end
 
-  defp do_check_group_gates([_gate | rest], item, temp_result) do
-    do_check_group_gates(rest, item, temp_result)
+  defp check_group_gates([_gate | rest], item, temp_result) do
+    check_group_gates(rest, item, temp_result)
   end
 
 


### PR DESCRIPTION
This is a clean up step after merging https://github.com/tompave/fun_with_flags/pull/172.

Now there is no need for distinct `check_actor_gates` and `do_check_actor_gates` functions. Same for the `group` functions.