### PR TITLE
Remove unused comment within mix.exs file

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -63,7 +63,6 @@ defmodule FunWithFlags.Mixfile do
         apps
       end
 
-    # IO.puts("Alocal_extra_applicationsPPS: #{inspect(apps)}")
     apps
   end
 


### PR DESCRIPTION
Noticed this while reading the release commits. Thanks for all the hard work on this project!