### PR TITLE
Improve Phoenix PubSub subscribe retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add support for Elixir 1.18. Drop support for Elixir 1.15. Elixir >= 1.16 is now required. Dropping support for older versions of Elixir simply means that this package is no longer tested with them in CI, and that compatibility issues are not considered bugs.
 * Drop support for Erlang/OTP 24, and Erlang/OTP >= 25 is now required. Dropping support for older versions of Erlang/OTP simply means that this package is not tested with them in CI, and that no compatibility issues are considered bugs.
+* Improve how the change-notification Phoenix.PubSub adapter manages its connection and readiness status. ([pull/191](https://github.com/tompave/fun_with_flags/pull/191))
 
 ## v1.12.0
 

--- a/test/fun_with_flags/notifications/phoenix_pubsub_test.exs
+++ b/test/fun_with_flags/notifications/phoenix_pubsub_test.exs
@@ -24,6 +24,23 @@ defmodule FunWithFlags.Notifications.PhoenixPubSubTest do
     end
   end
 
+  describe "subscribed?()" do
+    test "it returns true if the GenServer is subscribed to the pubsub topic" do
+      assert :ok = GenServer.call(PubSub, {:test_helper_set_subscription_status, :subscribed})
+      assert true = PubSub.subscribed?()
+
+      # Kill the process to restore its normal state.
+      kill_process(PubSub)
+    end
+
+    test "it returns false if the GenServer is not subscribed to the pubsub topic" do
+      assert :ok = GenServer.call(PubSub, {:test_helper_set_subscription_status, :unsubscribed})
+      assert false == PubSub.subscribed?()
+
+      # Kill the process to restore its normal state.
+      kill_process(PubSub)
+    end
+  end
 
   describe "publish_change(flag_name)" do
     setup do

--- a/test/fun_with_flags/notifications/phoenix_pubsub_test.exs
+++ b/test/fun_with_flags/notifications/phoenix_pubsub_test.exs
@@ -31,6 +31,7 @@ defmodule FunWithFlags.Notifications.PhoenixPubSubTest do
 
       # Kill the process to restore its normal state.
       kill_process(PubSub)
+      wait_until_pubsub_is_ready!()
     end
 
     test "it returns false if the GenServer is not subscribed to the pubsub topic" do
@@ -39,6 +40,7 @@ defmodule FunWithFlags.Notifications.PhoenixPubSubTest do
 
       # Kill the process to restore its normal state.
       kill_process(PubSub)
+      wait_until_pubsub_is_ready!()
     end
   end
 


### PR DESCRIPTION
With Elixir 1.18, the Phoenix PubSub tests had become very flaky locally. This was because the tests where running before the change notifications GenServer could fully subscribe to the notifications topic.

This PR fixes that with a new system to track the subscription status, plus new test helpers to assert with retries, rather than waiting for a timer.