### PR TITLE
Add timestamps migration

### DIFF
--- a/lib/fun_with_flags/store/persistent/ecto/record.ex
+++ b/lib/fun_with_flags/store/persistent/ecto/record.ex
@@ -13,6 +13,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto.Record do
     field :gate_type, :string
     field :target, :string
     field :enabled, :boolean
+    timestamps(type: :utc_datetime)
   end
 
   @fields [:flag_name, :gate_type, :target, :enabled]

--- a/priv/ecto_repo/migrations/00000000000001_add_timestamps.exs
+++ b/priv/ecto_repo/migrations/00000000000001_add_timestamps.exs
@@ -1,0 +1,17 @@
+defmodule FunWithFlags.Dev.EctoRepo.Migrations.AddTimestamps do
+  use Ecto.Migration
+
+  def up do
+    alter table(:fun_with_flags_toggles) do
+      add :inserted_at, :utc_datetime, null: false, default: fragment("CURRENT_TIMESTAMP")
+      add :updated_at, :utc_datetime, null: false, default: fragment("CURRENT_TIMESTAMP")
+    end
+  end
+
+  def down do
+    alter table(:fun_with_flags_toggles) do
+      remove :inserted_at
+      remove :updated_at
+    end
+  end
+end


### PR DESCRIPTION
Hey @tompave, I’ve created the first PR containing just migration timestamps.
 I love how Oban handles migrations with versioning:
https://github.com/oban-bg/oban/blob/main/lib/oban/migration.ex
Maybe we can implement a similar migrator here, what do you think?