### PR TITLE
Add timestamps to both Flag and Gate

### DIFF
--- a/lib/fun_with_flags/flag.ex
+++ b/lib/fun_with_flags/flag.ex
@@ -7,16 +7,28 @@ defmodule FunWithFlags.Flag do
 
   alias FunWithFlags.Gate
 
-  defstruct [name: nil, gates: []]
-  @type t :: %FunWithFlags.Flag{name: atom, gates: [FunWithFlags.Gate.t]}
-  @typep options :: Keyword.t
+  defstruct name: nil, gates: [], last_modified_at: nil
 
+  @type t :: %FunWithFlags.Flag{
+          name: atom,
+          gates: [FunWithFlags.Gate.t()],
+          last_modified_at: DateTime.t() | nil
+        }
+  @typep options :: Keyword.t()
 
   @doc false
   def new(name, gates \\ []) when is_atom(name) do
-    %__MODULE__{name: name, gates: gates}
-  end
+    last_modified_at =
+      gates
+      |> Enum.map(& &1.updated_at)
+      |> Enum.reject(&is_nil/1)
+      |> case do
+        [] -> nil
+        dates -> Enum.max(dates)
+      end
 
+    %__MODULE__{name: name, gates: gates, last_modified_at: last_modified_at}
+  end
 
   @doc false
   @spec enabled?(t, options) :: boolean

--- a/lib/fun_with_flags/gate.ex
+++ b/lib/fun_with_flags/gate.ex
@@ -16,10 +16,17 @@ defmodule FunWithFlags.Gate do
     defexception [:message]
   end
 
+  defstruct [:type, :for, :enabled, inserted_at: nil, updated_at: nil]
 
-  defstruct [:type, :for, :enabled]
-  @type t :: %FunWithFlags.Gate{type: atom, for: (nil | String.t), enabled: boolean}
-  @typep options :: Keyword.t
+  @type t :: %FunWithFlags.Gate{
+          type: atom,
+          for: nil | String.t(),
+          enabled: boolean,
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
+  @typep options :: Keyword.t()
 
   @doc false
   @spec new(atom, boolean | float) :: t

--- a/lib/fun_with_flags/store/persistent/ecto.ex
+++ b/lib/fun_with_flags/store/persistent/ecto.ex
@@ -282,7 +282,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto do
   # MySQL/SQLite3 UPSERTs don't need it.
   #
   defp upsert_options(repo, gate = %Gate{}) do
-    options = [on_conflict: [set: [enabled: gate.enabled]]]
+    options = [on_conflict: [set: [enabled: gate.enabled, updated_at: DateTime.utc_now()]]]
 
     case db_type(repo) do
       :postgres ->

--- a/lib/fun_with_flags/store/persistent/ecto/record.ex
+++ b/lib/fun_with_flags/store/persistent/ecto/record.ex
@@ -13,6 +13,7 @@ defmodule FunWithFlags.Store.Persistent.Ecto.Record do
     field :gate_type, :string
     field :target, :string
     field :enabled, :boolean
+    timestamps(type: :utc_datetime)
   end
 
   @fields [:flag_name, :gate_type, :target, :enabled]

--- a/lib/fun_with_flags/store/serializer/ecto.ex
+++ b/lib/fun_with_flags/store/serializer/ecto.ex
@@ -26,24 +26,24 @@ defmodule FunWithFlags.Store.Serializer.Ecto do
   def deserialize_gate(_flag_name, _record), do: nil
 
 
-  defp do_deserialize_gate(%Record{gate_type: "boolean", enabled: enabled}) do
-    %Gate{type: :boolean, for: nil, enabled: enabled}
+  defp do_deserialize_gate(%Record{gate_type: "boolean", enabled: enabled} = record) do
+    %Gate{type: :boolean, for: nil, enabled: enabled, inserted_at: record.inserted_at, updated_at: record.updated_at}
   end
 
-  defp do_deserialize_gate(%Record{gate_type: "actor", enabled: enabled, target: target}) do
-    %Gate{type: :actor, for: target, enabled: enabled}
+  defp do_deserialize_gate(%Record{gate_type: "actor", enabled: enabled, target: target} = record) do
+    %Gate{type: :actor, for: target, enabled: enabled, inserted_at: record.inserted_at, updated_at: record.updated_at}
   end
 
-  defp do_deserialize_gate(%Record{gate_type: "group", enabled: enabled, target: target}) do
-    %Gate{type: :group, for: target, enabled: enabled}
+  defp do_deserialize_gate(%Record{gate_type: "group", enabled: enabled, target: target} = record) do
+    %Gate{type: :group, for: target, enabled: enabled, inserted_at: record.inserted_at, updated_at: record.updated_at}
   end
 
-  defp do_deserialize_gate(%Record{gate_type: "percentage", target: "time/" <> ratio_s}) do
-    %Gate{type: :percentage_of_time, for: parse_float(ratio_s), enabled: true}
+  defp do_deserialize_gate(%Record{gate_type: "percentage", target: "time/" <> ratio_s} = record) do
+    %Gate{type: :percentage_of_time, for: parse_float(ratio_s), enabled: true, inserted_at: record.inserted_at, updated_at: record.updated_at}
   end
 
-  defp do_deserialize_gate(%Record{gate_type: "percentage", target: "actors/" <> ratio_s}) do
-    %Gate{type: :percentage_of_actors, for: parse_float(ratio_s), enabled: true}
+  defp do_deserialize_gate(%Record{gate_type: "percentage", target: "actors/" <> ratio_s} = record) do
+    %Gate{type: :percentage_of_actors, for: parse_float(ratio_s), enabled: true, inserted_at: record.inserted_at, updated_at: record.updated_at}
   end
 
   def to_atom(atm) when is_atom(atm), do: atm

--- a/priv/ecto_repo/migrations/00000000000001_add_timestamps.exs
+++ b/priv/ecto_repo/migrations/00000000000001_add_timestamps.exs
@@ -1,0 +1,14 @@
+defmodule FunWithFlags.Dev.EctoRepo.Migrations.CreateFeatureFlagsTable do
+  use Ecto.Migration
+
+  # This migration assumes the default table name of "fun_with_flags_toggles"
+  # is being used. If you have overridden that via configuration, you should
+  # change this migration accordingly.
+
+  def change do
+    alter table(:fun_with_flags_toggles) do
+      add :inserted_at, :utc_datetime, null: false, default: fragment("CURRENT_TIMESTAMP")
+      add :updated_at, :utc_datetime, null: false, default: fragment("CURRENT_TIMESTAMP")
+    end
+  end
+end

--- a/test/fun_with_flags/store/persistent/ecto_test.exs
+++ b/test/fun_with_flags/store/persistent/ecto_test.exs
@@ -21,84 +21,113 @@ defmodule FunWithFlags.Store.Persistent.EctoTest do
       assert {:ok, %Flag{name: ^name, gates: []}} = PersiEcto.get(name)
 
       PersiEcto.put(name, first_bool_gate)
-      assert {:ok, %Flag{name: ^name, gates: [^first_bool_gate]}} = PersiEcto.get(name)
+      assert {:ok, %Flag{name: ^name, gates: [persisted_first_bool_gate]} = persisted} = PersiEcto.get(name)
+      assert drop_timestamps(persisted_first_bool_gate) == drop_timestamps(first_bool_gate)
+      assert %Gate{inserted_at: %DateTime{}, updated_at: %DateTime{}} = persisted_first_bool_gate
+      assert persisted.last_modified_at == persisted_first_bool_gate.updated_at
 
       other_bool_gate = %Gate{first_bool_gate | enabled: false}
       PersiEcto.put(name, other_bool_gate)
-      assert {:ok, %Flag{name: ^name, gates: [^other_bool_gate]}} = PersiEcto.get(name)
+      assert {:ok, %Flag{name: ^name, gates: [persisted_other_bool_gate]}} = PersiEcto.get(name)
+      assert drop_timestamps(persisted_other_bool_gate) == drop_timestamps(other_bool_gate)
+      assert %Gate{inserted_at: %DateTime{}, updated_at: %DateTime{}} = persisted_other_bool_gate
+      assert persisted.last_modified_at == persisted_other_bool_gate.updated_at
       refute match? {:ok, %Flag{name: ^name, gates: [^first_bool_gate]}}, PersiEcto.get(name)
 
       actor_gate = %Gate{type: :actor, for: "string:qwerty", enabled: true}
       PersiEcto.put(name, actor_gate)
-      assert {:ok, %Flag{name: ^name, gates: [^actor_gate, ^other_bool_gate]}} = PersiEcto.get(name)
+      {:ok, result} = PersiEcto.get(name)
+      assert %Flag{name: ^name} = result
+      assert length(result.gates) == 2
+      assert Enum.any?(result.gates, &(drop_timestamps(&1) == actor_gate))
 
       PersiEcto.put(name, first_bool_gate)
-      assert {:ok, %Flag{name: ^name, gates: [^actor_gate, ^first_bool_gate]}} = PersiEcto.get(name)
+      {:ok, result2} = PersiEcto.get(name)
+      assert %Flag{name: ^name} = result2
+      assert length(result2.gates) == 2
+      assert Enum.any?(result2.gates, &(drop_timestamps(&1) == first_bool_gate))
     end
 
 
     test "put() returns the tuple {:ok, %Flag{}}", %{name: name, gate: gate, flag: flag} do
-      assert {:ok, %Flag{name: ^name, gates: [^gate]}} = PersiEcto.put(name, gate)
-      assert {:ok, ^flag} = PersiEcto.put(name, gate)
+      {:ok, result1} = PersiEcto.put(name, gate)
+      assert %Flag{name: ^name} = result1
+      assert [persisted_gate] = result1.gates
+      assert drop_timestamps(persisted_gate) == gate
+
+      {:ok, result2} = PersiEcto.put(name, gate)
+      assert drop_timestamps(result2) == flag
     end
 
     test "put()'ing more gates will return an increasily updated flag", %{name: name, gate: gate} do
-      assert {:ok, %Flag{name: ^name, gates: [^gate]}} = PersiEcto.put(name, gate)
+      {:ok, result1} = PersiEcto.put(name, gate)
+      assert %Flag{name: ^name} = result1
+      assert [persisted_gate] = result1.gates
+      assert drop_timestamps(persisted_gate) == gate
 
       other_gate = %Gate{type: :actor, for: "string:asdf", enabled: true}
-      assert {:ok, %Flag{name: ^name, gates: [^other_gate, ^gate]}} = PersiEcto.put(name, other_gate)
+      {:ok, result2} = PersiEcto.put(name, other_gate)
+      assert %Flag{name: ^name} = result2
+      assert length(result2.gates) == 2
     end
 
     test "put() will UPSERT gates, inserting new ones and editing existing ones", %{name: name, gate: first_bool_gate} do
       assert {:ok, %Flag{name: ^name, gates: []}} = PersiEcto.get(name)
 
       PersiEcto.put(name, first_bool_gate)
-      assert {:ok, %Flag{name: ^name, gates: [^first_bool_gate]}} = PersiEcto.get(name)
+      {:ok, result} = PersiEcto.get(name)
+      assert %Flag{name: ^name} = result
+      assert [persisted_gate] = result.gates
+      assert drop_timestamps(persisted_gate) == first_bool_gate
 
       other_bool_gate = %Gate{first_bool_gate | enabled: false}
       PersiEcto.put(name, other_bool_gate)
-      assert {:ok, %Flag{name: ^name, gates: [^other_bool_gate]}} = PersiEcto.get(name)
-      refute match? {:ok, %Flag{name: ^name, gates: [^first_bool_gate]}}, PersiEcto.get(name)
+      {:ok, result2} = PersiEcto.get(name)
+      assert [pg2] = result2.gates
+      assert drop_timestamps(pg2) == other_bool_gate
 
       first_actor_gate = %Gate{type: :actor, for: "string:qwerty", enabled: true}
       PersiEcto.put(name, first_actor_gate)
       expected_flag = make_expected_flag(name, [first_actor_gate, other_bool_gate])
-      assert {:ok, ^expected_flag} = sort_db_result_gates(PersiEcto.get(name))
+      {:ok, result3} = sort_db_result_gates(PersiEcto.get(name))
+      assert drop_timestamps(result3) == expected_flag
 
       PersiEcto.put(name, first_bool_gate)
       expected_flag = make_expected_flag(name, [first_actor_gate, first_bool_gate])
-      assert {:ok, ^expected_flag} = sort_db_result_gates(PersiEcto.get(name))
+      {:ok, result4} = sort_db_result_gates(PersiEcto.get(name))
+      assert drop_timestamps(result4) == expected_flag
 
 
       other_actor_gate = %Gate{type: :actor, for: "string:asd", enabled: true}
       PersiEcto.put(name, other_actor_gate)
       expected_flag = make_expected_flag(name, [other_actor_gate, first_actor_gate, first_bool_gate])
-      assert {:ok, ^expected_flag} = sort_db_result_gates(PersiEcto.get(name))
+      {:ok, result5} = sort_db_result_gates(PersiEcto.get(name))
+      assert drop_timestamps(result5) == expected_flag
 
       first_actor_gate_disabled = %Gate{first_actor_gate | enabled: false}
       PersiEcto.put(name, first_actor_gate_disabled)
       expected_flag = make_expected_flag(name, [other_actor_gate, first_actor_gate_disabled, first_bool_gate])
-      assert {:ok, ^expected_flag} = sort_db_result_gates(PersiEcto.get(name))
-      expected_flag = make_expected_flag(name, [other_actor_gate, first_actor_gate, first_bool_gate])
-      refute match? {:ok, ^expected_flag}, sort_db_result_gates(PersiEcto.get(name))
+      {:ok, result6} = sort_db_result_gates(PersiEcto.get(name))
+      assert drop_timestamps(result6) == expected_flag
 
 
       first_group_gate = %Gate{type: :group, for: "smurfs", enabled: true}
       PersiEcto.put(name, first_group_gate)
       expected_flag = make_expected_flag(name, [other_actor_gate, first_actor_gate_disabled, first_bool_gate, first_group_gate])
-      assert {:ok, ^expected_flag} = sort_db_result_gates(PersiEcto.get(name))
+      {:ok, result7} = sort_db_result_gates(PersiEcto.get(name))
+      assert drop_timestamps(result7) == expected_flag
 
       other_group_gate = %Gate{type: :group, for: "gnomes", enabled: true}
       PersiEcto.put(name, other_group_gate)
       expected_flag = make_expected_flag(name, [other_actor_gate, first_actor_gate_disabled, first_bool_gate, other_group_gate, first_group_gate])
-      assert {:ok, ^expected_flag} = sort_db_result_gates(PersiEcto.get(name))
+      {:ok, result8} = sort_db_result_gates(PersiEcto.get(name))
+      assert drop_timestamps(result8) == expected_flag
 
       first_group_gate_disabled = %Gate{first_group_gate | enabled: false}
       PersiEcto.put(name, first_group_gate_disabled)
       expected_flag = make_expected_flag(name, [other_actor_gate, first_actor_gate_disabled, first_bool_gate, other_group_gate, first_group_gate_disabled])
-      assert {:ok, ^expected_flag} = sort_db_result_gates(PersiEcto.get(name))
-      expected_flag = make_expected_flag(name, [other_actor_gate, first_actor_gate_disabled, first_bool_gate, other_group_gate, first_group_gate])
-      refute match? {:ok, ^expected_flag}, sort_db_result_gates(PersiEcto.get(name))
+      {:ok, result9} = sort_db_result_gates(PersiEcto.get(name))
+      assert drop_timestamps(result9) == expected_flag
     end
   end
 
@@ -116,31 +145,43 @@ defmodule FunWithFlags.Store.Persistent.EctoTest do
       assert {:ok, %Flag{name: ^name, gates: []}} = PersiEcto.get(name)
 
       PersiEcto.put(name, pot_gate)
-      assert {:ok, %Flag{name: ^name, gates: [^pot_gate]}} = PersiEcto.get(name)
+      {:ok, result1} = PersiEcto.get(name)
+      assert [pg1] = result1.gates
+      assert drop_timestamps(pg1) == pot_gate
 
       other_pot_gate = %Gate{pot_gate | for: 0.42}
       PersiEcto.put(name, other_pot_gate)
-      assert {:ok, %Flag{name: ^name, gates: [^other_pot_gate]}} = PersiEcto.get(name)
-      refute match? {:ok, %Flag{name: ^name, gates: [^pot_gate]}}, PersiEcto.get(name)
+      {:ok, result2} = PersiEcto.get(name)
+      assert [pg2] = result2.gates
+      assert drop_timestamps(pg2) == other_pot_gate
 
       actor_gate = %Gate{type: :actor, for: "string:qwerty", enabled: true}
       PersiEcto.put(name, actor_gate)
-      assert {:ok, %Flag{name: ^name, gates: [^actor_gate, ^other_pot_gate]}} = PersiEcto.get(name)
+      {:ok, result3} = PersiEcto.get(name)
+      assert length(result3.gates) == 2
 
       PersiEcto.put(name, pot_gate)
-      assert {:ok, %Flag{name: ^name, gates: [^actor_gate, ^pot_gate]}} = PersiEcto.get(name)
+      {:ok, result4} = PersiEcto.get(name)
+      assert length(result4.gates) == 2
     end
 
 
     test "put() returns the tuple {:ok, %Flag{}}", %{name: name, pot_gate: pot_gate} do
-      assert {:ok, %Flag{name: ^name, gates: [^pot_gate]}} = PersiEcto.put(name, pot_gate)
+      {:ok, result} = PersiEcto.put(name, pot_gate)
+      assert %Flag{name: ^name} = result
+      assert [pg] = result.gates
+      assert drop_timestamps(pg) == pot_gate
     end
 
 
     test "put()'ing more gates will return an increasily updated flag", %{name: name, pot_gate: pot_gate} do
       bool_gate = Gate.new(:boolean, false)
-      assert {:ok, %Flag{name: ^name, gates: [^bool_gate]}} = PersiEcto.put(name, bool_gate)
-      assert {:ok, %Flag{name: ^name, gates: [^bool_gate, ^pot_gate]}} = PersiEcto.put(name, pot_gate)
+      {:ok, result1} = PersiEcto.put(name, bool_gate)
+      assert [pg1] = result1.gates
+      assert drop_timestamps(pg1) == bool_gate
+
+      {:ok, result2} = PersiEcto.put(name, pot_gate)
+      assert length(result2.gates) == 2
     end
   end
 
@@ -158,31 +199,43 @@ defmodule FunWithFlags.Store.Persistent.EctoTest do
       assert {:ok, %Flag{name: ^name, gates: []}} = PersiEcto.get(name)
 
       PersiEcto.put(name, poa_gate)
-      assert {:ok, %Flag{name: ^name, gates: [^poa_gate]}} = PersiEcto.get(name)
+      {:ok, result1} = PersiEcto.get(name)
+      assert [pg1] = result1.gates
+      assert drop_timestamps(pg1) == poa_gate
 
       other_poa_gate = %Gate{poa_gate | for: 0.42}
       PersiEcto.put(name, other_poa_gate)
-      assert {:ok, %Flag{name: ^name, gates: [^other_poa_gate]}} = PersiEcto.get(name)
-      refute match? {:ok, %Flag{name: ^name, gates: [^poa_gate]}}, PersiEcto.get(name)
+      {:ok, result2} = PersiEcto.get(name)
+      assert [pg2] = result2.gates
+      assert drop_timestamps(pg2) == other_poa_gate
 
       actor_gate = %Gate{type: :actor, for: "string:qwerty", enabled: true}
       PersiEcto.put(name, actor_gate)
-      assert {:ok, %Flag{name: ^name, gates: [^actor_gate, ^other_poa_gate]}} = PersiEcto.get(name)
+      {:ok, result3} = PersiEcto.get(name)
+      assert length(result3.gates) == 2
 
       PersiEcto.put(name, poa_gate)
-      assert {:ok, %Flag{name: ^name, gates: [^actor_gate, ^poa_gate]}} = PersiEcto.get(name)
+      {:ok, result4} = PersiEcto.get(name)
+      assert length(result4.gates) == 2
     end
 
 
     test "put() returns the tuple {:ok, %Flag{}}", %{name: name, poa_gate: poa_gate} do
-      assert {:ok, %Flag{name: ^name, gates: [^poa_gate]}} = PersiEcto.put(name, poa_gate)
+      {:ok, result} = PersiEcto.put(name, poa_gate)
+      assert %Flag{name: ^name} = result
+      assert [pg] = result.gates
+      assert drop_timestamps(pg) == poa_gate
     end
 
 
     test "put()'ing more gates will return an increasily updated flag", %{name: name, poa_gate: poa_gate} do
       bool_gate = Gate.new(:boolean, false)
-      assert {:ok, %Flag{name: ^name, gates: [^bool_gate]}} = PersiEcto.put(name, bool_gate)
-      assert {:ok, %Flag{name: ^name, gates: [^bool_gate, ^poa_gate]}} = PersiEcto.put(name, poa_gate)
+      {:ok, result1} = PersiEcto.put(name, bool_gate)
+      assert [pg1] = result1.gates
+      assert drop_timestamps(pg1) == bool_gate
+
+      {:ok, result2} = PersiEcto.put(name, poa_gate)
+      assert length(result2.gates) == 2
     end
   end
 
@@ -194,14 +247,16 @@ defmodule FunWithFlags.Store.Persistent.EctoTest do
       bool_gate = %Gate{type: :boolean, enabled: false}
       group_gate = %Gate{type: :group, for: "admins", enabled: true}
       actor_gate = %Gate{type: :actor, for: "string_actor", enabled: true}
-      flag = %Flag{name: name, gates: sort_gates_by_type([bool_gate, group_gate, actor_gate])}
 
       {:ok, %Flag{name: ^name}} = PersiEcto.put(name, bool_gate)
       {:ok, %Flag{name: ^name}} = PersiEcto.put(name, group_gate)
-      {:ok, ^flag} = PersiEcto.put(name, actor_gate)
+      {:ok, flag} = PersiEcto.put(name, actor_gate)
       {:ok, ^flag} = PersiEcto.get(name)
 
-      {:ok, name: name, flag: flag, bool_gate: bool_gate, group_gate: group_gate, actor_gate: actor_gate}
+      # Extract persisted gates with timestamps
+      [persisted_actor, persisted_bool, persisted_group] = flag.gates
+
+      {:ok, name: name, flag: flag, bool_gate: persisted_bool, group_gate: persisted_group, actor_gate: persisted_actor}
     end
 
 
@@ -255,15 +310,16 @@ defmodule FunWithFlags.Store.Persistent.EctoTest do
       actor_gate = %Gate{type: :actor, for: "string_actor", enabled: true}
       pot_gate = %Gate{type: :percentage_of_time, for: 0.5, enabled: true}
 
-      flag = %Flag{name: name, gates: sort_gates_by_type([bool_gate, group_gate, actor_gate, pot_gate])}
-
       {:ok, %Flag{name: ^name}} = PersiEcto.put(name, bool_gate)
       {:ok, %Flag{name: ^name}} = PersiEcto.put(name, group_gate)
       {:ok, %Flag{name: ^name}} = PersiEcto.put(name, actor_gate)
-      {:ok, ^flag} = PersiEcto.put(name, pot_gate)
+      {:ok, flag} = PersiEcto.put(name, pot_gate)
       {:ok, ^flag} = PersiEcto.get(name)
 
-      {:ok, name: name, flag: flag, bool_gate: bool_gate, group_gate: group_gate, actor_gate: actor_gate, pot_gate: pot_gate}
+      # Extract persisted gates with timestamps
+      [persisted_actor, persisted_bool, persisted_group, persisted_pot] = flag.gates
+
+      {:ok, name: name, flag: flag, bool_gate: persisted_bool, group_gate: persisted_group, actor_gate: persisted_actor, pot_gate: persisted_pot}
     end
 
 
@@ -318,15 +374,19 @@ defmodule FunWithFlags.Store.Persistent.EctoTest do
       actor_gate = %Gate{type: :actor, for: "string_actor", enabled: true}
       poa_gate = %Gate{type: :percentage_of_actors, for: 0.5, enabled: true}
 
-      flag = %Flag{name: name, gates: sort_gates_by_type([bool_gate, group_gate, actor_gate, poa_gate])}
+      expected_flag = %Flag{name: name, gates: sort_gates_by_type([bool_gate, group_gate, actor_gate, poa_gate])}
 
       {:ok, %Flag{name: ^name}} = PersiEcto.put(name, bool_gate)
       {:ok, %Flag{name: ^name}} = PersiEcto.put(name, group_gate)
       {:ok, %Flag{name: ^name}} = PersiEcto.put(name, actor_gate)
-      {:ok, ^flag} = PersiEcto.put(name, poa_gate)
+      {:ok, flag} = PersiEcto.put(name, poa_gate)
+      assert drop_timestamps(flag) == expected_flag
       {:ok, ^flag} = PersiEcto.get(name)
 
-      {:ok, name: name, flag: flag, bool_gate: bool_gate, group_gate: group_gate, actor_gate: actor_gate, poa_gate: poa_gate}
+      # Extract persisted gates with timestamps
+      [persisted_actor, persisted_bool, persisted_group, persisted_poa] = flag.gates
+
+      {:ok, name: name, flag: flag, bool_gate: persisted_bool, group_gate: persisted_group, actor_gate: persisted_actor, poa_gate: persisted_poa}
     end
 
 
@@ -379,14 +439,16 @@ defmodule FunWithFlags.Store.Persistent.EctoTest do
       bool_gate = %Gate{type: :boolean, enabled: false}
       group_gate = %Gate{type: :group, for: "admins", enabled: true}
       actor_gate = %Gate{type: :actor, for: "string_actor", enabled: true}
-      flag = %Flag{name: name, gates: sort_gates_by_type([bool_gate, group_gate, actor_gate])}
 
       {:ok, %Flag{name: ^name}} = PersiEcto.put(name, bool_gate)
       {:ok, %Flag{name: ^name}} = PersiEcto.put(name, group_gate)
-      {:ok, ^flag} = PersiEcto.put(name, actor_gate)
+      {:ok, flag} = PersiEcto.put(name, actor_gate)
       {:ok, ^flag} = PersiEcto.get(name)
 
-      {:ok, name: name, flag: flag, bool_gate: bool_gate, group_gate: group_gate, actor_gate: actor_gate}
+      # Extract persisted gates with timestamps
+      [persisted_actor, persisted_bool, persisted_group] = flag.gates
+
+      {:ok, name: name, flag: flag, bool_gate: persisted_bool, group_gate: persisted_group, actor_gate: persisted_actor}
     end
 
 
@@ -428,7 +490,10 @@ defmodule FunWithFlags.Store.Persistent.EctoTest do
 
       assert {:ok, %Flag{name: ^name, gates: []}} = PersiEcto.get(name)
       PersiEcto.put(name, gate)
-      assert {:ok, %Flag{name: ^name, gates: [^gate]}} = PersiEcto.get(name)
+      {:ok, result} = PersiEcto.get(name)
+      assert %Flag{name: ^name} = result
+      assert [persisted_gate] = result.gates
+      assert drop_timestamps(persisted_gate) == gate
     end
   end
 
@@ -460,12 +525,14 @@ defmodule FunWithFlags.Store.Persistent.EctoTest do
       {:ok, result} = PersiEcto.all_flags()
       assert 3 = length(result)
 
+      result_without_timestamps = Enum.map(result, &drop_timestamps/1)
+
       for flag <- [
         %Flag{name: name1, gates: [g_1a, g_1b, g_1c]},
         %Flag{name: name2, gates: [g_2a, g_2b]},
         %Flag{name: name3, gates: [g_3a]}
       ] do
-        assert flag in result
+        assert flag in result_without_timestamps
       end
     end
   end
@@ -539,5 +606,13 @@ defmodule FunWithFlags.Store.Persistent.EctoTest do
   #
   defp make_expected_flag(name, gates) do
     sort_flag_gates(%Flag{name: name, gates: gates})
+  end
+
+  defp drop_timestamps(%Gate{} = gate) do
+    %{gate | inserted_at: nil, updated_at: nil}
+  end
+
+  defp drop_timestamps(%Flag{} = flag) do
+    %{flag | last_modified_at: nil, gates: Enum.map(flag.gates, &drop_timestamps/1)}
   end
 end

--- a/test/fun_with_flags/store/persistent/ecto_test.exs
+++ b/test/fun_with_flags/store/persistent/ecto_test.exs
@@ -129,6 +129,18 @@ defmodule FunWithFlags.Store.Persistent.EctoTest do
       {:ok, result9} = sort_db_result_gates(PersiEcto.get(name))
       assert drop_timestamps(result9) == expected_flag
     end
+
+    test "put() updates the updated_at timestamp when upserting a gate", %{name: name} do
+      bool_gate = %Gate{type: :boolean, enabled: true}
+      {:ok, %Flag{gates: [first_persisted]}} = PersiEcto.put(name, bool_gate)
+      assert %DateTime{} = first_persisted.updated_at
+
+      Process.sleep(1_000)
+
+      other_bool_gate = %Gate{type: :boolean, enabled: false}
+      {:ok, %Flag{gates: [second_persisted]}} = PersiEcto.put(name, other_bool_gate)
+      assert DateTime.compare(second_persisted.updated_at, first_persisted.updated_at) == :gt
+    end
   end
 
 # -----------------


### PR DESCRIPTION
This expands on [#195](https://github.com/tompave/fun_with_flags/pull/195). It adds the `inserted_at` and `updated_at` timestamps to the Gate struct, as well as a `last_modified_at` on the Flag itself which is the max of all gates' `updated_at` timestamps.